### PR TITLE
Sr battle (WIP)

### DIFF
--- a/include/SisterRay/SisterRay.h
+++ b/include/SisterRay/SisterRay.h
@@ -8,6 +8,7 @@
 #include <SisterRay/routines.h>
 #include <SisterRay/data_addresses.h>
 #include <SisterRay/game_data_types.h>
+#include <SisterRay/scene_data.h>
 
 /*Macro for handling compilation in both C and C++*/
 #if defined(__cplusplus)

--- a/include/SisterRay/game_structs.h
+++ b/include/SisterRay/game_structs.h
@@ -3,32 +3,41 @@
 
 #include <SisterRay/types.h>
 
+typedef struct {
+    u8 entryPriority;
+    u8 entryOffset;
+    u8 attackerActorID;
+    u8 actionCommandIndex;
+    u16 actionAttackIndex;
+    u16 actionTargetmask;
+} BattleQueueEntry;
+
 //This struct has size 260h and is referenced by the main context ptr
 #pragma pack(push, 1)
 typedef struct {
     u32 attackerID; //0x00
     u32 attackerLevel; //0x04
-    u32 attackerEnemyIndex; //0x08
+    u32 enemySceneIndex; //0x08 This is the relative index in the scene, i.e 0 1 or 2 of a given actor
     u32 commandIndex; //0x0C
     u32 attackIndex; //0x10
     u32 animationBaseOffset; //0x14
     u32 targetMask; //0x18
     u32 activeAllies; //0x1C
     u32 animationScriptID; //0x20
-    u32 AttackEffectID; //0x24
-    u32 actionIDCopy; //0x28
-    u32 attackIDCopy; //0x2C
+    u32 animationEffectID; //0x24
+    u32 commandIndexCopy; //0x28
+    u32 attackIndexCopy; //0x2C
     u32 attackerMask; //0x30
     u32 partofAttackerMask; //034
     u32 MPCost; //0x38
-    u32 hitChance; //0x3C
+    u32 abilityHitRate; //0x3C
     u32 damageFormulaID; //0x40
     u32 attackElementsMask; //0x44
     u32 abilityPower; //0x48
     i32 attackerAtk; //0x4C
-    u32 targetStateMask; //0x50
+    u32 abilityTargetingFlags; //0x50
     u32 impactSound; //0x54
-    u32 critkSound; //0x58
+    u32 critAtkSound; //0x58
     u32 missAtkSound; //0x5C
     u32 cameraDataSingle; //0x60
     u32 cameraDataMultiple; //0x64
@@ -43,7 +52,7 @@ typedef struct {
     u32 inflictStatusChange; //0x8C
     u32 miscActionflags; //0x90
     u32 targetMaskCopy; //0x94
-    u32 attackIndexCopy; //0x98
+    u32 sceneAbilityIndex; //0x98
     u8 padding2[4];
     u32 formulaType; //0xA0
     u32 formulaID; //0xA4
@@ -56,7 +65,7 @@ typedef struct {
     u32 additionalEffectsModifer; //0xC0
     u32 abilityPowerCopy; //0xC4
     u32 attackerStatusMask; //0xC8
-    u32 miscAttackData; //0xCC
+    u32 targetReactionAnimation; //0xCC
     u32 unkDWord2; //0xD0
     u32 unkDWord3; //0xD4
     u32 throwFormulaPower; //0xD8
@@ -95,7 +104,7 @@ typedef struct {
     u32 targetLevel; //0x254
     u32 targetCurrentHP; //0x258
     u32 targeCurrentMP; //0x25C
-    u32 hitChanceCopy; //0x260
+    u32 finalHitRate; //0x260
 } DamageCalcStruct;
 #pragma pack(pop)
 
@@ -104,21 +113,21 @@ typedef struct {
 //An array of size ACTOR_ARRAY_SIZE w/ elements of size 0x68 exists at ARRAY_ACTOR_START
 #pragma pack(push, 1)
 typedef struct {
-    u32     statusMasks;
-    u32     stateFlags;
-    u8      index;
-    u8      level;
-    u8      unknown0;
-    u8      elementDamageMask;
-    u8      characterID;
-    u8      physAtk;
-    u8      magAtk;
-    u8      pEvade;
-    u8      idleAnimID;
-    u8      damageAnimID;
-    u8      backDamageMult;
-    u8      sizeScale;
-    u8      dexterity;
+    u32     statusMask;        //0x00
+    u32     stateFlags;        //0x04
+    u8      index;             //0x08
+    u8      level;             //0x09
+    u8      unknown0;          //0x0A
+    u8      elementDamageMask; //0x0B
+    u8      characterID;       //0x0C
+    u8      physAtk;           //0x0D
+    u8      magAtk;            //0x0E
+    u8      pEvade;            //0x0F
+    u8      idleAnimID;        //0x10
+    u8      damageAnimID;      //0x11
+    u8      backDamageMult;    //0x12
+    u8      sizeScale;         //0x13
+    u8      dexterity;         //0x14
     u8      luck;
     u8      idleAnimHolder;
     u8      lastCovered;
@@ -197,19 +206,70 @@ typedef struct {
 
 /*This is the structure of attack data*/
 typedef struct {
-    u8 padding[0x1C];
-} attackData;
+    u8 abilityHitRate; //0x00
+    u8 impactEffectID; //0x01
+    u8 targetReactionID; //0x02
+    u8 unkbyte;          //0x03
+    u16 MPCost;          //0x04
+    u16 impactSoundID;   //0x06
+    u16 cameraMovementSingle;   //0x08
+    u16 cameraMovementMultiple;  //0x0A
+    u8 targetingFlags;           //0x0C
+    u8 animationEffectID;        //0x0D
+    u8 damageFormula;            //0x0E
+    u8 attackPower;              //0x0F
+    u8 restoreTypes;             //0x10
+    u8 statusInfictType;         //0x11
+    u8 additionalEffect;         //0x12
+    u8 additionalEffectModifier;  //0x13
+    u32 statusMask;               //0x14
+    u16 elementMask;              //0x18
+    u16 specialAttackFlags;       //0x1A
+} AttackData;
+
+typedef struct {
+    char enemyName[32];       //0x00
+    u8 enemyLevel;            //0x20
+    u8 enemySpeed;            //0x21
+    u8 enemyLuck;             //0x22
+    u8 enemyEvade;            //0x23
+    u8 enemyStrength;         //0x24
+    u8 enemyDefense;          //0x25
+    u8 enemyMagic;            //0x26
+    u8 enemyMDefense;         //0x27
+    u8 elementTypes[8];       //0x28
+    u8 elementModifiers[8];   //0x30
+    u8 attackAnimScripts[16]; //0x38
+    u16 attackSceneIDs[16];   //0x48
+    u16 attackCameraIDs[16];  //0x68
+    u8 itemStealDropRates[4]; //0x88
+    u16 itemsToStealDrop[4];  //0x8C
+    u16 manipAttackIDs[3];    //0x94
+    u8 unknownBytes[2];       //0x9A
+    u16 enemyMP;              //0x9C
+    u16 apAward;              //0x9E
+    u16 morphItemID;          //0xA0
+    u8 backDamageMultipler;   //0xA2
+    u8 align;                 //0xA3
+    u32 enemyHP;              //0xA4
+    u32 expAward;             //0xA8
+    u32 gilAward;             //0xAC
+    u32 statusImmunityMask;   //0xB0
+    u8 unknown2[4];           //0xB4
+} EnemyData;
+
 
 /*This contains a bit vector of flags for spells*/
 #pragma pack(push, 1)
 typedef struct {
     u8 magicIndex;
     u8 mpCost;
-    u8 allCount;
+    u8 allCount; //used as summon count for summons
     u8 quadEnabled;
     u8 quadCount;
     u8 targetData;
-    u16 propertiesMask;
+    u8 propertiesMask;
+    u8 actorPropertiesMask; //HP Absorb, etc
 } spellFlags;
 #pragma pack(pop)
 
@@ -253,8 +313,8 @@ typedef struct {
     u32 attackStatusesMask; //0x44
     u32 immuneStatusesMask; //0x48
     enabledCommandStruct enabledCommandArray[0x10]; //0x4C
-    u8 unknownbytes[8]; //0xAC
-    attackData enabledLimitData[3]; //0xB4
+    u8 enabledLimitBytes[8]; //0xAC
+    AttackData enabledLimitData[3]; //0xB4
     spellFlags enabledMagicsData[54]; //0x108
     spellFlags unusedMagics[2]; //0x2B8
     spellFlags enabledSummons[16]; //0x2C8

--- a/include/SisterRay/game_structs.h
+++ b/include/SisterRay/game_structs.h
@@ -48,8 +48,8 @@ typedef struct {
     u32 unkTHATCRASHEDTHEGAME; // 0x7C
     u32 addStatusMask; //0x80
     u32 rmStatusMask; //0x84
-    u32 changeStatusMask; //0x88
-    u32 inflictStatusChange; //0x8C
+    u32 toggleStatusMask; //0x88
+    u32 inflictStatusChance; //0x8C
     u32 miscActionflags; //0x90
     u32 targetMaskCopy; //0x94
     u32 sceneAbilityIndex; //0x98
@@ -166,11 +166,10 @@ typedef struct {
     u8      unused13;
     u8      unused14;
     u8      unused15;
-
 } ActorBattleVars;
 #pragma pack(pop)
 
-#define gAiActorVariables   ((ActorBattleVars*)0x009AB0DC)
+#define gAiActorVariables   ((ActorBattleVars*)0x9AB0DC)
 
 /*Should  have size 0x1AEC*/
 #pragma pack(push, 1)
@@ -193,8 +192,8 @@ typedef struct {
 } ActorTimerBlock;
 #pragma pack(pop)
 
-#define gBigAnimBlock       ((BigAnimBlock*)0x00BE1170)
-#define gActorTimerBlock    ((ActorTimerBlock*)0x009A8B26)
+#define gBigAnimBlock       ((BigAnimBlock*)0xBE1170)
+#define gActorTimerBlock    ((ActorTimerBlock*)0x9A8B26)
 
 #pragma pack(push, 1)
 typedef struct {
@@ -226,38 +225,6 @@ typedef struct {
     u16 elementMask;              //0x18
     u16 specialAttackFlags;       //0x1A
 } AttackData;
-
-typedef struct {
-    char enemyName[32];       //0x00
-    u8 enemyLevel;            //0x20
-    u8 enemySpeed;            //0x21
-    u8 enemyLuck;             //0x22
-    u8 enemyEvade;            //0x23
-    u8 enemyStrength;         //0x24
-    u8 enemyDefense;          //0x25
-    u8 enemyMagic;            //0x26
-    u8 enemyMDefense;         //0x27
-    u8 elementTypes[8];       //0x28
-    u8 elementModifiers[8];   //0x30
-    u8 attackAnimScripts[16]; //0x38
-    u16 attackSceneIDs[16];   //0x48
-    u16 attackCameraIDs[16];  //0x68
-    u8 itemStealDropRates[4]; //0x88
-    u16 itemsToStealDrop[4];  //0x8C
-    u16 manipAttackIDs[3];    //0x94
-    u8 unknownBytes[2];       //0x9A
-    u16 enemyMP;              //0x9C
-    u16 apAward;              //0x9E
-    u16 morphItemID;          //0xA0
-    u8 backDamageMultipler;   //0xA2
-    u8 align;                 //0xA3
-    u32 enemyHP;              //0xA4
-    u32 expAward;             //0xA8
-    u32 gilAward;             //0xAC
-    u32 statusImmunityMask;   //0xB0
-    u8 unknown2[4];           //0xB4
-} EnemyData;
-
 
 /*This contains a bit vector of flags for spells*/
 #pragma pack(push, 1)
@@ -330,10 +297,26 @@ typedef struct {
     u8 encounterRate;
     u8 chocoboChance;
     u8 preEmptiveChance;
-} activePartyMemberStruct;
+} ActivePartyMemberStruct;
 #pragma pack(pop)
 
-#define activePartyStructArray   ((activePartyMemberStruct*)0xDBA498)
+#define activePartyStructArray ((ActivePartyMemberStruct*)0xDBA498)
+
+#pragma pack(push, 1)
+typedef struct {
+    u8 characterID; //0x00
+    u8 unkByte1;    //0x01
+    u8 unkByte2;    //0x02
+    u8 unkByte3;    //0x03
+    u8 unkByte4;    //0x04
+    u8 align;       //0x05
+    u16 unkWrd1;    //0x06
+    u32 unkDWrd1;   //0x08
+    u32 unkDwrd2;   //0x0C
+} UnkPartyStruct;
+#pragma pack(pop)
+
+#define gUnkPartyDataArray ((UnkPartyStruct*)0x9A87F4)
 
 #pragma pack(push, 1)
 typedef struct {

--- a/include/SisterRay/routines.h
+++ b/include/SisterRay/routines.h
@@ -30,6 +30,9 @@
 #define INIT_BATTLE_ITEM_MENU_CURSOR    ((void*)0x6D982C)
 #define BATTLE_ITEM_MENU_INPUT_HANDLER  ((void*)0x6D98E3)
 #define EQUIP_MENU_UPDATE_HANDLER       ((void*)0x705D16)
+#define LOAD_ABILITY_DATA_HANDLER       ((void*)0x5C94D3)
+#define LOAD_FORMATION_HANDLER          ((void*)0x5D1050)
+#define EXECUTE_AI_SCRIPT_HANDLER       ((void*)0x5C86E0)
 
 typedef void(*pfnnullmasks)();
 typedef void(*pfnenqueueaction)(u16, u16, u8, u8, u16);

--- a/include/SisterRay/routines.h
+++ b/include/SisterRay/routines.h
@@ -34,6 +34,8 @@
 #define LOAD_FORMATION_HANDLER          ((void*)0x5D1050)
 #define EXECUTE_AI_SCRIPT_HANDLER       ((void*)0x5C86E0)
 #define EXECUTE_FORMATION_SCRIPT_HANDLER ((void*)0x5C8931)
+#define ENQUEUE_SCRIPT_ACTION           ((void*)0x5D969C)
+#define TRANSFORM_ENEMY_COMMAND         ((void*)0x5C93A1)
 
 typedef void(*pfnnullmasks)();
 typedef void(*pfnenqueueaction)(u16, u16, u8, u8, u16);

--- a/include/SisterRay/routines.h
+++ b/include/SisterRay/routines.h
@@ -193,4 +193,14 @@ typedef i32(*pfnsub70760F)(i32, i32, i32);
 
 typedef i32(*pfnsub6F54A2)(u8*);
 #define sub_6F54A2                      ((pfnsub6F54A2)0x6F54A2) //Does returns x position from a text ptr, probably a centering util
+
+//The following functions are used by the battle module
+typedef void(*pfnsub5CA722)(i32, i32);
+#define copyAdditionalEffects           ((pfnsub5CA722)0x5CA722)
+
+typedef void(*pfnsub435139)(i32, u8, u8, i16);
+#define srCreateEvent                   ((pfnsub435139)0x435139)
+
+typedef i32(*pfnsub5C8684)(u32, u32);
+#define getLimitRelativeIndex           ((pfnsub5C8684)0x5C8684)
 #endif

--- a/include/SisterRay/routines.h
+++ b/include/SisterRay/routines.h
@@ -33,6 +33,7 @@
 #define LOAD_ABILITY_DATA_HANDLER       ((void*)0x5C94D3)
 #define LOAD_FORMATION_HANDLER          ((void*)0x5D1050)
 #define EXECUTE_AI_SCRIPT_HANDLER       ((void*)0x5C86E0)
+#define EXECUTE_FORMATION_SCRIPT_HANDLER ((void*)0x5C8931)
 
 typedef void(*pfnnullmasks)();
 typedef void(*pfnenqueueaction)(u16, u16, u8, u8, u16);

--- a/include/SisterRay/scene_data.h
+++ b/include/SisterRay/scene_data.h
@@ -1,5 +1,117 @@
 #ifndef SCENE_DATA_H
 #define SCENE_DATA_H
 
+#include "game_data_types.h"
+
+#pragma pack(push, 1)
+typedef struct {
+    char enemyName[32];       //0x00
+    u8 enemyLevel;            //0x20
+    u8 enemySpeed;            //0x21
+    u8 enemyLuck;             //0x22
+    u8 enemyEvade;            //0x23
+    u8 enemyStrength;         //0x24
+    u8 enemyDefense;          //0x25
+    u8 enemyMagic;            //0x26
+    u8 enemyMDefense;         //0x27
+    u8 elementTypes[8];       //0x28
+    u8 elementModifiers[8];   //0x30
+    u8 attackAnimScripts[16]; //0x38
+    u16 attackSceneIDs[16];   //0x48
+    u16 attackCameraIDs[16];  //0x68
+    u8 itemStealDropRates[4]; //0x88
+    u16 itemsToStealDrop[4];  //0x8C
+    u16 manipAttackIDs[3];    //0x94
+    u8 unknownBytes[2];       //0x9A
+    u16 enemyMP;              //0x9C
+    u16 apAward;              //0x9E
+    u16 morphItemID;          //0xA0
+    u8 backDamageMultipler;   //0xA2
+    u8 align;                 //0xA3
+    u32 enemyHP;              //0xA4
+    u32 expAward;             //0xA8
+    u32 gilAward;             //0xAC
+    u32 statusImmunityMask;   //0xB0
+    u8 unknown2[4];           //0xB4
+} EnemyData;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct {
+    u16 EnemyIds[3];
+    u16 terminator; //always 0xFF
+} FormationEnemies;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct {
+    u16 battleLocation;
+    u16 nextFormationID;
+    u16 escapeCounter;
+    u16 align;
+    u16 battleArenaCandidates[4]; //one of the four formation entries listed will be be fetched for the next ID
+    u16 battleFlags;
+    u8 battleType; //side attack, etc
+    u8 initCameraID;
+} FormationSetup;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct {
+    u16 xCoordinate;
+    u16 yCoordinate;
+    u16 zCoordinate;
+    u16 xVector;
+    u16 yVector;
+    u16 zVector;
+} CameraData;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct {
+    CameraData mainCamera;
+    CameraData animationCams[2];
+    u8 padding[12]; //always 0xFFFF -- we might be able to extend/relocate this buffer to enable more camera positions for more dynamic battles
+} FormationCamera;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct {
+    u16 enemyID; //This is an index into SrEnemyRegistry -- 0xFFFF by default
+    u16 xCoordinate;
+    u16 yCoordinate;
+    u16 zCoordinate;
+    u16 actorRow;
+    u16 coverFlags;
+    u32 initialStateFlags;
+} FormationActorData;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct {
+    FormationActorData formationDatas[6];
+} FormationActorDataArray;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct{
+    u8 name[32];
+} AttackNameFixedBuffer;
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+typedef struct {
+    FormationEnemies formationModelIDs;
+    FormationSetup formationSetupArray[4];
+    FormationCamera formationCameraArray[4];
+    FormationActorDataArray formationActorDataArrays[4];
+    EnemyData enemyDataArray[3];
+    AttackData enemyAttacksArray[32];
+    u16 enemyAttackIDS[32];
+    AttackNameFixedBuffer enemyAttackNames[32];
+    u8 formationAIData[512];
+    u8 enemyAIData[4096];
+} SceneLayout;
+#pragma pack(pop)
 
 #endif

--- a/include/SisterRay/scene_data.h
+++ b/include/SisterRay/scene_data.h
@@ -1,0 +1,5 @@
+#ifndef SCENE_DATA_H
+#define SCENE_DATA_H
+
+
+#endif

--- a/include/SisterRay/types.h
+++ b/include/SisterRay/types.h
@@ -13,7 +13,7 @@ typedef uint32_t    u32;
 
 #pragma pack(push, 1)
 struct i24 {
-    unsigned int data : 24;
+    unsigned int attackData : 24;
 };
 #pragma pack(pop)
 

--- a/src/EncodedString.cpp
+++ b/src/EncodedString.cpp
@@ -2,15 +2,12 @@
 #include <cstdint>
 #include "EncodedString.h"
 
-EncodedString::EncodedString()
-: _size(0)
-{
+EncodedString::EncodedString() : _size(0) {
     _str = new char[1];
     _str[0] = (char)0xff;
 }
 
-EncodedString::EncodedString(const char* str)
-{
+EncodedString::EncodedString(const char* str) {
     size_t i;
 
     i = 0;
@@ -21,20 +18,16 @@ EncodedString::EncodedString(const char* str)
     memcpy(_str, str, i + 1);
 }
 
-EncodedString::EncodedString(const EncodedString& other)
-: _size(other._size)
-{
+EncodedString::EncodedString(const EncodedString& other) : _size(other._size) {
     _str = new char[_size + 1];
     memcpy(_str, other._str, _size + 1);
 }
 
-EncodedString::~EncodedString()
-{
+EncodedString::~EncodedString() {
     delete[] _str;
 }
 
-EncodedString& EncodedString::operator=(const EncodedString& other)
-{
+EncodedString& EncodedString::operator=(const EncodedString& other) {
     delete[] _str;
     _size = other._size;
     _str = new char[_size + 1];
@@ -43,13 +36,11 @@ EncodedString& EncodedString::operator=(const EncodedString& other)
     return *this;
 }
 
-const char* EncodedString::str() const
-{
+const char* EncodedString::str() const {
     return _str;
 }
 
-const char* EncodedString::unicode() const
-{
+const char* EncodedString::unicode() const {
     static const char* kCharset =
         " !\"#$%&'()*+,-./"
         "0123456789:;<=>?"
@@ -76,13 +67,11 @@ const char* EncodedString::unicode() const
     return buffer;
 }
 
-size_t EncodedString::size() const
-{
+size_t EncodedString::size() const {
     return _size;
 }
 
-EncodedString EncodedString::from_unicode(const char* str)
-{
+EncodedString EncodedString::from_unicode(const char* str) {
     static char buffer[16384];
     static const uint8_t kReverseCharset[256] = {
         0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/src/battle/ai_scripts.cpp
+++ b/src/battle/ai_scripts.cpp
@@ -1,0 +1,23 @@
+#include "ai_scripts.h"
+
+
+u8* getScriptPtr(const BattleAIData& AIData, u16 scriptType) {
+    switch (scriptType) {
+        case 0:
+            return AIData.initScript.data();
+        case 1:
+            return AIData.mainScript.data();
+        case 2:
+            return AIData.genCounter.data();
+        case 3:
+            return AIData.deathCounter.data();
+        case 4:
+            return AIData.physCounter.data();
+        case 5:
+            return AIData.magCounter.data();
+        case 6:
+            return AIData.endBattle.data();
+        case 7:
+            return AIData.preActionScript.data;
+    }
+}

--- a/src/battle/ai_scripts.cpp
+++ b/src/battle/ai_scripts.cpp
@@ -150,4 +150,5 @@ void copyAIScript(AIScript& aiScript, const u8* const scriptStart) {
         aiScript.push_back(*scriptPosition);
         scriptPosition++;
     }
+    aiScript.push_back(0x73);
 }

--- a/src/battle/ai_scripts.cpp
+++ b/src/battle/ai_scripts.cpp
@@ -1,23 +1,117 @@
 #include "ai_scripts.h"
 
 
-u8* getScriptPtr(const BattleAIData& AIData, u16 scriptType) {
+const u8* getScriptPtr(const BattleAIData& AIData, u16 scriptType) {
     switch (scriptType) {
         case 0:
-            return AIData.initScript.data();
+            if (!AIData.initScript.empty())
+                return AIData.initScript.data();
+            break;
         case 1:
-            return AIData.mainScript.data();
+            if (!AIData.mainScript.empty())
+                return AIData.mainScript.data();
+            break;
         case 2:
-            return AIData.genCounter.data();
+            if (!AIData.genCounter.empty())
+                return AIData.genCounter.data();
+            break;
         case 3:
-            return AIData.deathCounter.data();
+            if (!AIData.deathCounter.empty())
+                return AIData.deathCounter.data();
+            break;
         case 4:
-            return AIData.physCounter.data();
+            if (!AIData.physCounter.empty())
+                return AIData.physCounter.data();
+            break;
         case 5:
-            return AIData.magCounter.data();
+            if (!AIData.magCounter.empty())
+                return AIData.magCounter.data();
+            break;
         case 6:
-            return AIData.endBattle.data();
+            if (!AIData.endBattle.empty())
+                return AIData.endBattle.data();
+            break;
         case 7:
-            return AIData.preActionScript.data;
+            if (!AIData.preActionScript.empty())
+                return AIData.preActionScript.data();
+            break;
+    }
+    return nullptr;
+}
+
+/*These functions take a script block from scene.bin and parse it into an SR internal format*/
+void initializeBattleAIData(const u8* const scriptBlock, u32 sceneEnemyIndex, BattleAIData& srAIData) {
+    u16* sceneAIEnemyOffsets = (u16*)scriptBlock;
+    auto enemyScriptsOffset = sceneAIEnemyOffsets[sceneEnemyIndex];
+    auto aiDataPtr = scriptBlock + enemyScriptsOffset;
+    initAIScriptStruct(srAIData, aiDataPtr);
+}
+
+void initializeFormationAIScript(const u8* const scriptBlock, u32 formationIndex, BattleAIData& srAIData) {
+    u16* sceneAIEnemyOffsets = (u16*)scriptBlock;
+    auto formationIndexOffset = sceneAIEnemyOffsets[formationIndex];
+    auto aiDataPtr = scriptBlock + formationIndexOffset;
+    initAIScriptStruct(srAIData, aiDataPtr);
+}
+
+void initAIScriptStruct(BattleAIData& srAIData, const u8* const scriptBlockStart) {
+    const u16* const wordReader = (const u16* const)scriptBlockStart;
+    SceneAIOffsets scriptStarts = { wordReader[0], wordReader[1], wordReader[2], wordReader[3], wordReader[4], wordReader[5], wordReader[6], wordReader[7], wordReader[8] };
+    auto scriptStart = scriptBlockStart + scriptStarts.initScript;
+
+    /*This is a bit ugly, consider refactoring the AI data stucture later so a loop will work*/
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.initScript, scriptStart);
+    }
+
+    scriptStart = scriptBlockStart + scriptStarts.mainScript;
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.mainScript, scriptStart);
+    }
+
+    scriptStart = scriptBlockStart + scriptStarts.genCounter;
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.genCounter, scriptStart);
+    }
+
+    scriptStart = scriptBlockStart + scriptStarts.physCounter;
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.physCounter, scriptStart);
+    }
+
+    scriptStart = scriptBlockStart + scriptStarts.magCounter;
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.magCounter, scriptStart);
+    }
+
+    scriptStart = scriptBlockStart + scriptStarts.preActionScript;
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.preActionScript, scriptStart);
+    }
+
+    scriptStart = scriptBlockStart + scriptStarts.deathCounter;
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.deathCounter, scriptStart);
+    }
+
+    scriptStart = scriptBlockStart + scriptStarts.endBattle;
+    if (*scriptStart != 0xFFFFFFFF) {
+        copyAIScript(srAIData.endBattle, scriptStart);
+    }
+
+    for (auto customEventIndex = 0; customEventIndex < 8; customEventIndex++) {
+        scriptStart = scriptBlockStart + scriptStarts.customEventScripts[customEventIndex];
+        if (*scriptStart != 0xFFFFFFFF) {
+            copyAIScript(srAIData.customEventScripts[customEventIndex], scriptStart);
+        }
+    }
+
+}
+
+void copyAIScript(AIScript& aiScript, const u8* const scriptStart) {
+    auto scriptPosition = scriptStart;
+    while (*scriptPosition != 0x73) {
+        aiScript.push_back(*scriptPosition);
+        scriptPosition++;
     }
 }

--- a/src/battle/ai_scripts.h
+++ b/src/battle/ai_scripts.h
@@ -1,0 +1,26 @@
+#ifndef AI_SCRIPTS_H
+#define AI_SCRIPTS_H
+
+#include <SisterRay/SisterRay.h>
+#include <vector>
+
+typedef const std::vector<u8> AIScript;
+
+/*Struct which contains u8 ptrs to indexes in the underlying buffer*/
+typedef struct {
+    AIScript initScript;
+    AIScript mainScript;
+    AIScript genCounter;
+    AIScript deathCounter;
+    AIScript physCounter;
+    AIScript magCounter;
+    AIScript endBattle;
+    AIScript preActionScript;
+    AIScript customEvent[8];
+} BattleAIData;
+
+u8* getScriptPtr(const BattleAIData& AIData, u16 scriptType);
+void updateScript(AIScript script, AIScript newData, u32 insertIndex);
+
+
+#endif

--- a/src/battle/ai_scripts.h
+++ b/src/battle/ai_scripts.h
@@ -4,7 +4,19 @@
 #include <SisterRay/SisterRay.h>
 #include <vector>
 
-typedef const std::vector<u8> AIScript;
+typedef std::vector<u8> AIScript;
+
+typedef struct {
+    u16 initScript;
+    u16 mainScript;
+    u16 genCounter;
+    u16 deathCounter;
+    u16 physCounter;
+    u16 magCounter;
+    u16 endBattle;
+    u16 preActionScript;
+    u16 customEventScripts[8];
+} SceneAIOffsets;
 
 /*Struct which contains u8 ptrs to indexes in the underlying buffer*/
 typedef struct {
@@ -16,11 +28,14 @@ typedef struct {
     AIScript magCounter;
     AIScript endBattle;
     AIScript preActionScript;
-    AIScript customEvent[8];
+    AIScript customEventScripts[8];
 } BattleAIData;
 
-u8* getScriptPtr(const BattleAIData& AIData, u16 scriptType);
-void updateScript(AIScript script, AIScript newData, u32 insertIndex);
+const u8* getScriptPtr(const BattleAIData& AIData, u16 scriptType);
+void initializeBattleAIData(const u8* const scriptBlock, u32 sceneEnemyIndex, BattleAIData& srAIData);
+void initializeFormationAIScript(const u8* const scriptBlock, u32 formationIndex, BattleAIData& srAIData);
+void copyAIScript(AIScript& aiScript, const u8* const scriptStart);
+void initAIScriptStruct(BattleAIData& srAIData, const u8* const scriptBlockStart);
 
 
 #endif

--- a/src/battle/battle.cpp
+++ b/src/battle/battle.cpp
@@ -6,6 +6,7 @@
 #include <zlib.h>
 #include <cstdio>
 #include <memory>
+#include "../EncodedString.h"
 
 #define BLOCK_SIZE 0x2000
 #define SCENE_SIZE 0x1E80
@@ -27,25 +28,32 @@ typedef i32(*pfnsub5D9550)(i32, i32, i32);
 
 /*Initialize SR registries for enemy/formation data from scene.bin*/
 void initFormationsRegistries() {
+    srLogWrite("Initializing registries from scene.bin");
     u8* sceneBlock = (u8*)malloc(BLOCK_SIZE);
     SceneLayout currentScene = SceneLayout();
     u16 sceneBlockIndex = 0;
     u16 formationIndex = 0;
     const char* filename = "data/battle/scene.bin";
     u32 sceneSize = getFileSize(filename);
+    u32 sceneBlockIdx = 0;
     while (sceneSize >= BLOCK_SIZE) {
         readBlock(filename, BLOCK_SIZE, sceneBlock); //We read a scene block into memory, need to determine when last block is reached
         u16 byteSizes[16];
         auto sceneCount = getCompressedFileSizes(sceneBlock, byteSizes); //get the number of scenes in the block and their sizes
+        srLogWrite("Loading %i total scenes from block %i", sceneCount, sceneBlockIdx);
         for (auto sceneIndex = 0; sceneIndex < sceneCount; sceneIndex++) {
+            srLogWrite("loading scene %i from block %i", sceneIndex, sceneBlockIdx);
             u32 compressedSize = byteSizes[sceneIndex]; //We need to seek the actual end of the last scene
+            srLogWrite("compressed size is: %i", byteSizes[sceneIndex]);
             const u8* compressedScenePtr = sceneBlock + 4 * (*(sceneBlock + 4 * sceneIndex)); //points to the start of the gzipped scene file inside the buffer
             auto readSize = srGzipInflateCpy(compressedScenePtr, compressedSize, (u8*)&currentScene, sizeof(SceneLayout));
+            srLogWrite("scene has been decompressed");
             if (readSize != SCENE_SIZE)
                 srLogWrite("ERROR: decompressed scene file is not the right size. Expected size: 7802, actual size %i", readSize);
             populateRegistries(currentScene, &formationIndex); //this mutates formation index and populates formation, enemy data, and enemy ability registries. 
         }
         sceneSize -= BLOCK_SIZE;
+        sceneBlockIdx++;
     }
     free(sceneBlock);
 }
@@ -102,30 +110,33 @@ void readBlock(const char* filename, u32 blockSize, u8* dst) {
 
 /*Populate Enemy, Formation, and Enemy Attack Registries*/
 void populateRegistries(const SceneLayout& sceneData, u16* formationIndex) {
+    srLogWrite("unpacking scene into internal SR registries");
     auto sceneIndex = (*formationIndex) / 4;
     std::string sceneName = std::to_string(sceneIndex);
-    FormationEnemyIDs uniqueIDs;
+    FormationEnemyIDs srEnemyIDs = FormationEnemyIDs();
 
     /*Insert the enemies into an enemy registry. They are hashed given a unique ID: Scene Index: Name*/
     for (auto enemyIndex = 0; enemyIndex < 3; enemyIndex++) {
-        SrEnemyData enemyData = SrEnemyData();
-        enemyData.enemyData = sceneData.enemyDataArray[enemyIndex];
-        enemyData.modelID = sceneData.formationModelIDs.EnemyIds[enemyIndex];
-        auto enemyName = std::string(enemyData.enemyData.enemyName);
+        SrEnemyData srEnemyData = SrEnemyData();
+        srEnemyData.enemyData = sceneData.enemyDataArray[enemyIndex];
+        srEnemyData.modelID = sceneData.formationModelIDs.EnemyIds[enemyIndex];
+        auto enemyName = std::string(EncodedString(srEnemyData.enemyData.enemyName).unicode());
         auto uniqueID = sceneName + enemyName;
-        uniqueIDs.uniqueIDs[enemyIndex] = uniqueID;
+        srEnemyIDs.uniqueIDs[enemyIndex] = uniqueID;
 
         BattleAIData enemyAIData = BattleAIData();
         initializeBattleAIData(&(sceneData.enemyAIData[0]), enemyIndex, enemyAIData);
-        enemyData.enemyAI = enemyAIData;
+        srEnemyData.enemyAI = enemyAIData;
         /*Add enemies to the enemy registry*/
-        gContext.enemies.add_element(uniqueID, enemyData);
+        gContext.enemies.add_element(uniqueID, srEnemyData);
+        srLogWrite("Enemy:%s added to registry", uniqueID.c_str());
     }
+    srLogWrite("scene enemies registerd");
 
     /*Create a formation referencing the unique enemy IDs*/
     for (auto sceneFormationIndex = 0; sceneFormationIndex < 4; sceneFormationIndex++) {
         FormationData formation = FormationData();
-        formation.FormationEnemyIDs = uniqueIDs; //Probably want to remove this, reconstructing it from the SR unique IDs when a battle is loaded
+        formation.FormationEnemyIDs = srEnemyIDs; //Probably want to remove this, reconstructing it from the SR unique IDs when a battle is loaded
         formation.formationSetup = sceneData.formationSetupArray[sceneFormationIndex];
         formation.formationCamera = sceneData.formationCameraArray[sceneFormationIndex];
         formation.formationActorDataArray = sceneData.formationActorDataArrays[sceneFormationIndex];
@@ -135,22 +146,41 @@ void populateRegistries(const SceneLayout& sceneData, u16* formationIndex) {
         formation.formationAI = formationAI;
         gContext.formations.add_element(formationName, formation);
         *formationIndex = *formationIndex + 1;
+        srLogWrite("Formation:%s added to registry with enemies %s, %s, %s",
+            formationName.c_str(),
+            formation.FormationEnemyIDs.uniqueIDs[0].c_str(),
+            formation.FormationEnemyIDs.uniqueIDs[1].c_str(),
+            formation.FormationEnemyIDs.uniqueIDs[2].c_str()
+        );
     }
+    srLogWrite("scene formations registered");
 
     /*Duduplicate enemy abilities and put them into a registry by attack ID. They can be fetched via the string form of their attack ID*/
-    auto enemyAttacks = sceneData.enemyAttacksArray;
-    auto enemyAttackNames = sceneData.enemyAttackNames;
-    auto enemyAttackIDs = sceneData.enemyAttackIDS;
+    auto& enemyAttacks = sceneData.enemyAttacksArray;
+    auto& enemyAttackNames = sceneData.enemyAttackNames;
+    srLogWrite("enemyAttackNames located at %p", &sceneData.enemyAttackNames);
+    auto& enemyAttackIDs = sceneData.enemyAttackIDS;
     for (auto attackIndex = 0; attackIndex < 32; attackIndex++) {
         auto attackID = enemyAttackIDs[attackIndex];
         auto stringID = std::to_string(attackID);
+        if (attackID == 0xFFFF)
+            continue;
+
         if (!(gContext.enemyAttacks.contains(stringID))) { //must implement a method to check if the dictionary contains a key
-            auto attackName = std::string((char*)&(enemyAttackNames[attackIndex].name));
+            srLogWrite("loading enemy ability name from %p", &(enemyAttackNames[attackIndex].name));
+            auto attackName = EncodedString((const char *)enemyAttackNames[attackIndex].name);
             auto attackData = enemyAttacks[attackIndex];
             EnemyAttack enemyAttack = { attackData, attackID, attackName };
             gContext.enemyAttacks.add_element(stringID, enemyAttack);
+            srLogWrite("Enemy Attack:%s added to registry with name:%s, and ID:%i",
+                stringID.c_str(),
+                enemyAttack.attackName.unicode(),
+                enemyAttack.attackID
+            );
         }
     }
+    srLogWrite("scene enemy abilities registered");
+    srLogWrite("scene fully registered!");
 }
 
 i16 loadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void)) {

--- a/src/battle/battle.cpp
+++ b/src/battle/battle.cpp
@@ -1,0 +1,319 @@
+#include "battle.h"
+#include "../impl.h"
+#include "../gzip.h"
+#include "../party/party_utils.h"
+#include <string>
+#include <zlib.h>
+#include <cstdio>
+#include <memory>
+
+#define BLOCK_SIZE 0x2000
+#define SCENE_SIZE 0x1E80
+
+typedef u8*(*pfnsub436E15)(u8, u8, u8, i16);
+#define createAnimationEvent     ((pfnsub436E15)0x436E15)
+
+typedef i32(*pfnsub437185)(i32, i32, u8, i32);
+#define sub_437185               ((pfnsub437185)0x437185)
+
+typedef i32(*pfnsub5D7FE4)(i32, i32, i32);
+#define runAIScript              ((pfnsub5D7FE4)0x5D7FE4)
+
+typedef u8(*pfnsub5C8BA1)(void);
+#define getRandomNumber          ((pfnsub5C8BA1)0x5C8BA1)
+
+typedef i32(*pfnsub5D9550)(i32, i32, i32);
+#define sub_5D9550               ((pfnsub5D9550)0x5D9550)
+
+/*Initialize SR registries for enemy/formation data from scene.bin*/
+void initFormationsRegistries() {
+    u8* sceneBlock = (u8*)malloc(BLOCK_SIZE);
+    SceneLayout currentScene = SceneLayout();
+    u16 sceneBlockIndex = 0;
+    u16 formationIndex = 0;
+    const char* filename = "data/battle/scene.bin";
+    u32 sceneSize = getFileSize(filename);
+    while (sceneSize >= BLOCK_SIZE) {
+        readBlock(filename, BLOCK_SIZE, sceneBlock); //We read a scene block into memory, need to determine when last block is reached
+        u16 byteSizes[16];
+        auto sceneCount = getCompressedFileSizes(sceneBlock, byteSizes); //get the number of scenes in the block and their sizes
+        for (auto sceneIndex = 0; sceneIndex < sceneCount; sceneIndex++) {
+            u32 compressedSize = byteSizes[sceneIndex]; //We need to seek the actual end of the last scene
+            const u8* compressedScenePtr = sceneBlock + 4 * (*(sceneBlock + 4 * sceneIndex)); //points to the start of the gzipped scene file inside the buffer
+            auto readSize = srGzipInflateCpy(compressedScenePtr, compressedSize, (u8*)&currentScene, sizeof(SceneLayout));
+            if (readSize != SCENE_SIZE)
+                srLogWrite("ERROR: decompressed scene file is not the right size. Expected size: 7802, actual size %i", readSize);
+            populateRegistries(currentScene, &formationIndex); //this mutates formation index and populates formation, enemy data, and enemy ability registries. 
+        }
+        sceneSize -= BLOCK_SIZE;
+    }
+    free(sceneBlock);
+}
+
+/*Returns an array of compressed file sizes*/
+u32 getCompressedFileSizes(const u8* sceneBlock, u16 byteSizes[16]) {
+    auto sceneCount = 0;
+    const u32* blockRelativeOffset = (const u32*)sceneBlock;
+    u16 blockSceneIndex = 0;
+    while (*blockRelativeOffset != 0xFFFFFFFF) {
+        if (*(blockRelativeOffset + 1) == 0xFFFFFFFF) {
+            u16 endChar = findEndChar(sceneBlock);
+            byteSizes[blockSceneIndex] = endChar - (4 * (*blockRelativeOffset));
+        }
+        else {
+            byteSizes[blockSceneIndex] = 4 * (*(blockRelativeOffset + 1) - *blockRelativeOffset);
+        }
+        sceneCount++;
+        blockRelativeOffset++;
+        blockSceneIndex++;
+    }
+    return sceneCount;
+}
+
+/*utility searches a buffer backwards in order to locate the first not 0xFF char for decompressing the final buffer*/
+u16 findEndChar(const u8* sceneBlock) {
+    const u8* bufferEnd = sceneBlock + BLOCK_SIZE;
+    u16 endOffset = BLOCK_SIZE;
+    while (bufferEnd > sceneBlock) {
+        if (*bufferEnd != 0xFF) {
+            return endOffset;
+            break;
+        }
+        bufferEnd--;
+        endOffset--;
+    }
+    srLogWrite("ERROR: final gzip buffer end not found");
+}
+
+u32 getFileSize(const char* filename) {
+    FILE *fileHandle = NULL;
+    fileHandle = fopen(filename, "rb");
+    fseek(fileHandle, 0, SEEK_END);
+    u32 size = ftell(fileHandle);
+    fclose(fileHandle);
+    return size;
+}
+
+/*Read a scene block into a given buffer*/
+void readBlock(const char* filename, u32 blockSize, u8* dst) {
+    FILE* scenePtr = fopen(filename, "rb");
+    fread(dst, blockSize, 1, scenePtr);
+}
+
+/*Populate Enemy, Formation, and Enemy Attack Registries*/
+void populateRegistries(const SceneLayout& sceneData, u16* formationIndex) {
+    auto sceneIndex = (*formationIndex) / 4;
+    std::string sceneName = std::to_string(sceneIndex);
+    FormationEnemyIDs uniqueIDs;
+
+    /*Insert the enemies into an enemy registry. They are hashed given a unique ID: Scene Index: Name*/
+    for (auto enemyIndex = 0; enemyIndex < 3; enemyIndex++) {
+        SrEnemyData enemyData = SrEnemyData();
+        enemyData.enemyData = sceneData.enemyDataArray[enemyIndex];
+        enemyData.modelID = sceneData.formationModelIDs.EnemyIds[enemyIndex];
+        auto enemyName = std::string(enemyData.enemyData.enemyName);
+        auto uniqueID = sceneName + enemyName;
+        uniqueIDs.uniqueIDs[enemyIndex] = uniqueID;
+
+        BattleAIData enemyAIData = BattleAIData();
+        initializeBattleAIData(&(sceneData.enemyAIData[0]), enemyIndex, enemyAIData);
+        enemyData.enemyAI = enemyAIData;
+        /*Add enemies to the enemy registry*/
+        gContext.enemies.add_element(uniqueID, enemyData);
+    }
+
+    /*Create a formation referencing the unique enemy IDs*/
+    for (auto sceneFormationIndex = 0; sceneFormationIndex < 4; sceneFormationIndex++) {
+        FormationData formation = FormationData();
+        formation.FormationEnemyIDs = uniqueIDs; //Probably want to remove this, reconstructing it from the SR unique IDs when a battle is loaded
+        formation.formationSetup = sceneData.formationSetupArray[sceneFormationIndex];
+        formation.formationCamera = sceneData.formationCameraArray[sceneFormationIndex];
+        formation.formationActorDataArray = sceneData.formationActorDataArrays[sceneFormationIndex];
+        auto formationName = std::to_string(*formationIndex);
+        BattleAIData formationAI = BattleAIData();
+        initializeBattleAIData(&(sceneData.formationAIData[0]), sceneFormationIndex, formationAI);
+        formation.formationAI = formationAI;
+        gContext.formations.add_element(formationName, formation);
+        *formationIndex = *formationIndex + 1;
+    }
+
+    /*Duduplicate enemy abilities and put them into a registry by attack ID. They can be fetched via the string form of their attack ID*/
+    auto enemyAttacks = sceneData.enemyAttacksArray;
+    auto enemyAttackNames = sceneData.enemyAttackNames;
+    auto enemyAttackIDs = sceneData.enemyAttackIDS;
+    for (auto attackIndex = 0; attackIndex < 32; attackIndex++) {
+        auto attackID = enemyAttackIDs[attackIndex];
+        auto stringID = std::to_string(attackID);
+        if (!(gContext.enemyAttacks.contains(stringID))) { //must implement a method to check if the dictionary contains a key
+            auto attackName = std::string((char*)&(enemyAttackNames[attackIndex].name));
+            auto attackData = enemyAttacks[attackIndex];
+            EnemyAttack enemyAttack = { attackData, attackID, attackName };
+            gContext.enemyAttacks.add_element(stringID, enemyAttack);
+        }
+    }
+}
+
+i16 loadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void)) {
+    i16 ret; 
+    char v4; 
+    int enemyIndex;
+    void *v16; 
+    i32 sceneSize; 
+    i32 sceneIndex; 
+    FormationEnemies* formationEnemiesPtr = (FormationEnemies*)(0x9A8748);
+    FormationSetup* formationSetupPtr = (FormationSetup*)(0x9A8750);
+    FormationCamera* formationCameraPtr = (FormationCamera*)(0x9A8764);
+    FormationActorDataArray* formationActorDataPtr = (FormationActorDataArray*)(0x9A8794);
+    EnemyData* enemyDataPtr = (EnemyData*)(0x9A8E9C);
+    FormationEnemyIDs* sceneAIDataPtr = (FormationEnemyIDs*)(0x9A9CFC);
+    u32* dword_C069BC = (u32*)(0xC069BC);
+    u32* dword_9A89D0 = (u32*)(0x9A89D0);
+    u16* battleFlags = (u16*)(0x9A88A6);
+    u16* gFormationType = (u16*)(0x9AAD20);
+    u16* gEscapeFlag = (u16*)(0x9AAD0A);
+    u16* word_9AAD0E = (u16*)(0x9AAD0E);
+    u32* dword_9ACB68 = (u32*)(0x9ACB68);
+    u8* battleTypeArray = (u8*)(0x7B76F0);
+
+    ret = *dword_C069BC;  // this code coordinates, along with a2, additional setup for "next battle"
+    if (*dword_C069BC) {
+        if (*dword_C069BC != 1) {
+            if (*dword_C069BC != 2) {
+                *dword_C069BC = 0;
+                *dword_9A89D0 = 1;
+                return ret;
+            }
+            goto LABEL_11;
+        }
+    }
+    else {
+        *dword_C069BC = 1;
+    }
+    if (!modelAppearCallback) { //This contained a bunch of code which loads stuff from scene. This is not necessary now
+        *dword_C069BC = 2;
+
+    LABEL_11:
+        auto formationIDstr = std::to_string(formationIndex);
+        auto formation = gContext.formations.get_element(std::string(formationIDstr));
+        *formationSetupPtr = formation.formationSetup;
+        *formationCameraPtr = formation.formationCamera;
+        *formationActorDataPtr = formation.formationActorDataArray;
+
+        auto& uniqueEnemyIds = formation.FormationEnemyIDs;
+        for (auto enemyIndex = 0; enemyIndex < 3; enemyIndex++) {
+            auto currentEnemyData = gContext.enemies.get_element(uniqueEnemyIds.uniqueIDs[enemyIndex]);
+            formationEnemiesPtr->EnemyIds[enemyIndex] = currentEnemyData.modelID;
+            enemyDataPtr[enemyIndex] = currentEnemyData.enemyData;
+            /*While the original game copies AI data here, we parse AI scripts and store them with our registries
+              Ergo, we elect to store a battle accessible SR struct which contains unique enemy IDs here*/
+            *sceneAIDataPtr = formation.FormationEnemyIDs;
+        }
+
+        //Set pre-emptive in some circumstances
+        if ((*battleFlags & 4) && (formationSetupPtr->battleFlags & 0x10) && !(formationSetupPtr->battleType))
+            formationSetupPtr->battleType = 1;
+        *gFormationType = battleTypeArray[formationSetupPtr->battleType];
+
+        if (*battleFlags & 0x40) {                   // Boost stats in battle arena
+            formationSetupPtr->battleFlags |= 4u;
+            formationSetupPtr->battleLocation = 37;
+            formationSetupPtr->initCameraID = (getRandomNumber() & 3) + 96;
+            formationSetupPtr->escapeCounter = 1;
+            for (enemyIndex = 0; enemyIndex < 3; ++enemyIndex) { // boost all stats for battle arena, need to cap at 255
+                enemyDataPtr[enemyIndex].enemyHP = enemyDataPtr[enemyIndex].enemyHP * 2;
+                enemyDataPtr[enemyIndex].enemyStrength = (enemyDataPtr[enemyIndex].enemyStrength * 3) / 2;                
+                enemyDataPtr[enemyIndex].enemyMagic = (enemyDataPtr[enemyIndex].enemyMagic * 3) / 2;
+                enemyDataPtr[enemyIndex].enemyDefense = (enemyDataPtr[enemyIndex].enemyDefense * 3) / 2;
+                enemyDataPtr[enemyIndex].enemyMDefense = (enemyDataPtr[enemyIndex].enemyMDefense * 3) / 2;
+            }
+        }
+        else if (*battleFlags & 8) {
+            formationSetupPtr->battleFlags &= 0xFFFBu;
+        }
+
+        if (!(formationSetupPtr->battleFlags & 4))
+            *battleFlags |= 8u;
+
+        *gEscapeFlag = formationSetupPtr->escapeCounter;
+        if (*gFormationType == 1 || *gFormationType == 3)
+            *gEscapeFlag = 1;
+        ret = *gEscapeFlag;
+        *word_9AAD0E = *gEscapeFlag;
+        *dword_C069BC = 0;
+        *dword_9A89D0 = 1;
+        return ret;
+    }
+    ret = modelAppearCallback();
+    if (dword_9ACB68) {
+        dword_9ACB68 = 0;
+        *dword_C069BC = 2;
+    }
+    return ret;
+}
+
+i32 srExecuteAIScript(i32 actorIndex, i32 scriptType, i32 a3) {
+    i32 result;
+    scriptAnimDataCpy modelDataCpys[10];
+    const u8* scriptPtr = nullptr;
+    u8 characterScriptIndex = 0xFF; 
+    FormationActorDataArray* formationActorDataPtr = (FormationActorDataArray*)(0x9A8794);
+    FormationEnemyIDs* sceneAIDataPtr = (FormationEnemyIDs*)(0x9A9CFC);
+    u8* linkedScriptArray = (u8*)(0x8FEE38);
+
+    result = 1 << scriptType; 
+    u16* unknownPtr = (u16*)(0x9AAD14);
+    *unknownPtr |= 1 << scriptType;
+
+    switch (actorIndex) {
+        case 0:
+        case 1:
+        case 2: {
+            characterScriptIndex = gUnkPartyDataArray[actorIndex].characterID;
+            if (characterScriptIndex != -0xFF && linkedScriptArray[characterScriptIndex] != 0xFF) //this handles script links
+                characterScriptIndex = linkedScriptArray[characterScriptIndex];
+            // scriptPtr = getAIScriptPtr((i32)&formationAI, characterScriptIndex, scriptType);// characterAI //probably best if we run these AI scripts from an internal registry too
+            auto& charAIData = gContext.characters.get_element(getCharacterName(characterScriptIndex)).characterAI;
+            scriptPtr = getScriptPtr(charAIData, scriptType);
+            break;
+        }
+        case 3: {
+            break;
+        }
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9: {
+            auto formationEnemyID = formationActorDataPtr->formationDatas[actorIndex - 4].enemyID; //fetch the formation relative ID, it's modified from the absolute ID
+            auto uniqueID = sceneAIDataPtr->uniqueIDs[formationEnemyID];
+            auto& enemyAIData = gContext.enemies.get_element(uniqueID).enemyAI;
+            scriptPtr = getScriptPtr(enemyAIData, scriptType);
+            break;
+        }
+        default: {
+        }
+    }
+
+    if (scriptPtr) {
+        //Here we copy the animation index, size scale, and damaged animation of each actor so we can react if they are changed by scripts
+        for (auto actorID = 0; actorID < 10; ++actorID) {
+            modelDataCpys[actorID].sizeScale = gAiActorVariables[actorID].sizeScale;
+            modelDataCpys[actorID].idleAnim = gAiActorVariables[actorID].idleAnimID;
+            modelDataCpys[actorID].damagedAnim = gAiActorVariables[actorID].damageAnimID;
+        }
+
+        sub_5D9550(actorIndex, a3, 0); //Not sure what this function does yet
+        result = runAIScript(actorIndex, (i32)scriptPtr, characterScriptIndex);
+
+        /*If the size scale or animation has changed, we call some functions*/
+        for (auto actorID = 0; actorID < 10; ++actorID) {
+            if (modelDataCpys[actorID].sizeScale != gAiActorVariables[actorID].sizeScale)
+                createAnimationEvent(actorID, 4, gAiActorVariables[actorID].sizeScale, 16);
+
+            if (modelDataCpys[actorID].damagedAnim != gAiActorVariables[actorID].damageAnimID)
+                sub_437185(actorID, modelDataCpys[actorID].damagedAnim, gAiActorVariables[actorID].damageAnimID, 0);
+        }
+    }
+    return result;
+}

--- a/src/battle/battle.cpp
+++ b/src/battle/battle.cpp
@@ -277,6 +277,7 @@ i16 srLoadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void)) {
         dword_9ACB68 = 0;
         *dword_C069BC = 2;
     }
+    srLogWrite("Scene successfully loaded");
     return ret;
 }
 
@@ -293,6 +294,8 @@ i32 srExecuteAIScript(i32 actorIndex, i32 scriptType, i32 a3) {
     u16* unknownPtr = (u16*)(0x9AAD14);
     *unknownPtr |= 1 << scriptType;
 
+    srLogWrite("running AI script for actor %i of type %i", actorIndex, scriptType);
+
     switch (actorIndex) {
         case 0:
         case 1:
@@ -300,7 +303,6 @@ i32 srExecuteAIScript(i32 actorIndex, i32 scriptType, i32 a3) {
             characterScriptIndex = gUnkPartyDataArray[actorIndex].characterID;
             if (characterScriptIndex != -0xFF && linkedScriptArray[characterScriptIndex] != 0xFF) //this handles script links
                 characterScriptIndex = linkedScriptArray[characterScriptIndex];
-            // scriptPtr = getAIScriptPtr((i32)&formationAI, characterScriptIndex, scriptType);// characterAI //probably best if we run these AI scripts from an internal registry too
             auto& charAIData = gContext.characters.get_element(getCharacterName(characterScriptIndex)).characterAI;
             scriptPtr = getScriptPtr(charAIData, scriptType);
             break;
@@ -316,8 +318,13 @@ i32 srExecuteAIScript(i32 actorIndex, i32 scriptType, i32 a3) {
         case 9: {
             auto formationEnemyID = formationActorDataPtr->formationDatas[actorIndex - 4].enemyID; //fetch the formation relative ID, it's modified from the absolute ID
             auto uniqueID = sceneAIDataPtr->uniqueIDs[formationEnemyID];
+            srLogWrite("fetching script information for the following enemy: %s", uniqueID.c_str());
             auto& enemyAIData = gContext.enemies.get_element(uniqueID).enemyAI;
             scriptPtr = getScriptPtr(enemyAIData, scriptType);
+            if (scriptPtr) {
+                srLogWrite("executing enemy AI script with chars:%x %x %x %x %x %x %x %x %x %x %x %x",
+                    scriptPtr[0], scriptPtr[1], scriptPtr[2], scriptPtr[3], scriptPtr[4], scriptPtr[5], scriptPtr[6], scriptPtr[7], scriptPtr[8], scriptPtr[9], scriptPtr[10], scriptPtr[11]);
+            }
             break;
         }
         default: {

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -14,6 +14,8 @@ void initFormationsRegistries();
 i16 srLoadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void));
 i32 srExecuteAIScript(i32 actorIndex, i32 scriptID, i32 unkInt);
 i32 srExecuteFormationScripts();
+i32  enqueueScriptAction(i16 actorID, i16 commandIndex, i16 attackIndex);
+void* transformEnemyCommand();
 
 u32 getCompressedFileSizes(const u8* sceneBlock, u16 byteSizes[16]);
 void readBlock(FILE* filehandle, u32 blockSize, u8* dst);

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -11,8 +11,9 @@ typedef struct {
 } scriptAnimDataCpy;
 
 void initFormationsRegistries();
-i16 loadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void));
+i16 srLoadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void));
 i32 srExecuteAIScript(i32 actorIndex, i32 scriptID, i32 unkInt);
+i32 srExecuteFormationScripts();
 
 u32 getCompressedFileSizes(const u8* sceneBlock, u16 byteSizes[16]);
 void readBlock(FILE* filehandle, u32 blockSize, u8* dst);

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -1,0 +1,20 @@
+#ifndef BATTLE_H
+#define BATTLE_H
+
+#include <SisterRay/SisterRay.h>
+typedef struct {
+    u8 sizeScale;
+    u8 idleAnim;
+    u8 damagedAnim;
+} scriptAnimDataCpy;
+
+void initFormationsRegistries();
+i16 loadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void));
+i32 srExecuteAIScript(i32 actorIndex, i32 scriptID, i32 unkInt);
+
+u32 getCompressedFileSizes(const u8* sceneBlock, u16 byteSizes[16]);
+void readBlock(const char* filename, u32 blockSize, u8* dst);
+void populateRegistries(const SceneLayout& sceneData, u16* formationIndex);
+u16 findEndChar(const u8* sceneBlock);
+
+#endif

--- a/src/battle/battle.h
+++ b/src/battle/battle.h
@@ -2,6 +2,8 @@
 #define BATTLE_H
 
 #include <SisterRay/SisterRay.h>
+#include <cstdio>
+
 typedef struct {
     u8 sizeScale;
     u8 idleAnim;
@@ -13,7 +15,7 @@ i16 loadBattleFormation(i32 formationIndex, i32(*modelAppearCallback)(void));
 i32 srExecuteAIScript(i32 actorIndex, i32 scriptID, i32 unkInt);
 
 u32 getCompressedFileSizes(const u8* sceneBlock, u16 byteSizes[16]);
-void readBlock(const char* filename, u32 blockSize, u8* dst);
+void readBlock(FILE* filehandle, u32 blockSize, u8* dst);
 void populateRegistries(const SceneLayout& sceneData, u16* formationIndex);
 u16 findEndChar(const u8* sceneBlock);
 

--- a/src/battle/battle_context.cpp
+++ b/src/battle/battle_context.cpp
@@ -17,7 +17,7 @@ void srLoadAbilityData() {
         AttackData abilityData;
         BattleQueueEntry executingAction = (*(BattleQueueEntry*)0x9A9884);
         AttackData* currentSceneAbilities = (AttackData*)(0x9A90C4);
-        char* sceneAbilitiesPtr = (char*)(0x9A9484);
+        char* attackNamesPtr = (char*)(0x9A9484);
         u16* currentSceneAbilityIDs = (u16*)(0x9A9444);
         AttackData* kernelAbilities = (AttackData*)(0xDB9690);
         EnemyData* enemyData = (EnemyData*)(0x9A8E9C);
@@ -27,13 +27,6 @@ void srLoadAbilityData() {
         cameraOverrideData = 0xFFFF;
         deathSentenceFlag = 0;
         gDamageContextPtr->MPCost = -1;
-        srLogWrite("attempting to load ability data");
-        srLogWrite("command index being executed: %i", gDamageContextPtr->commandIndex);
-        srLogWrite("attack index being executed: %i", gDamageContextPtr->attackIndex);
-        srLogWrite("command index being executed: %i", gDamageContextPtr->commandIndexCopy);
-        srLogWrite("enemy action command index %i", CMD_ENEMY_ACTION);
-        srLogWrite("action index being executed: %i", gDamageContextPtr->attackIndexCopy);
-        srLogWrite("actor ID: %i", gDamageContextPtr->attackerID);
         if (gDamageContextPtr->commandIndexCopy == CMD_ENEMY_ACTION) {
             srLogWrite("Attempting to load enemy action");
             auto attackID = std::string(std::to_string(gDamageContextPtr->attackIndexCopy));
@@ -41,8 +34,10 @@ void srLoadAbilityData() {
             auto enemyAttack = gContext.enemyAttacks.get_element(attackID);
             abilityData = gContext.enemyAttacks.get_element(attackID).attackData;
             currentSceneAbilities[0] = enemyAttack.attackData;
-            memcpy((void*)sceneAbilitiesPtr, (void*)enemyAttack.attackName.str(), enemyAttack.attackName.size()); //We will need to verify that this actually works, strcpy might expect null termination and buffer overrun here
-            srLogWrite("attack name in registry: %s, copied attack name in unicode: %s", attackID.c_str(), EncodedString(((char*)sceneAbilitiesPtr)).unicode());
+            srLogWrite("size of attack name: %i", enemyAttack.attackName.size());
+            memcpy((void*)attackNamesPtr, (void*)(enemyAttack.attackName.str()), enemyAttack.attackName.size());
+            *(attackNamesPtr + enemyAttack.attackName.size()) = char(255);
+            srLogWrite("attack name in registry: %s, copied attack name in unicode: %s", attackID.c_str(), EncodedString(((char*)attackNamesPtr)).unicode());
             *currentSceneAbilityIDs = enemyAttack.attackID;
             srLogWrite("attack id at index 0: %i", *currentSceneAbilityIDs);
             gDamageContextPtr->sceneAbilityIndex = 0;

--- a/src/battle/battle_context.cpp
+++ b/src/battle/battle_context.cpp
@@ -33,7 +33,7 @@ void setContextFromAbility() {
             auto enemyAttack = gContext.enemyAttacks.get_element(attackID);
             abilityDataPtr = &(gContext.enemyAttacks.get_element(attackID).attackData);
             currentSceneAbilities[0] = enemyAttack.attackData;
-            strcpy(currentSceneAbilityNames, enemyAttack.attackName.c_str());
+            strcpy(currentSceneAbilityNames, enemyAttack.attackName.str()); //We will need to verify that this actually works, strcpy might expect null termination and buffer overrun here
             *currentSceneAbilityIDs = enemyAttack.attackID;
             gDamageContextPtr->sceneAbilityIndex = 0;
         }

--- a/src/battle/battle_context.cpp
+++ b/src/battle/battle_context.cpp
@@ -1,0 +1,157 @@
+#include "battle_context.h"
+#include "../impl.h"
+
+void setCurrentActionAbilityData() {
+        i32 sceneAbilityIndex; 
+        i32 enemyActionIndex;
+        u16 elementMask;
+        i32 fetchedRelativeIndex;
+        i32 limitAnimationScriptIndex; 
+        i32 relativeLimitIndex; 
+        u8 characterID; 
+        u8* activeLimitIDs; 
+        i32 relativeIndex; 
+        i32 charLimitArrayIndex; 
+        i32 deathSentenceFlag; 
+        u16 cameraOverrideData;
+        AttackData* abilityDataPtr;
+        BattleQueueEntry executingAction = (*(BattleQueueEntry*)0x9A9884);
+        AttackData* currentSceneAbilities = (AttackData*)(0x9A90C4);
+        AttackData* kernelAbilities = (AttackData*)(0xDB9690);
+        EnemyData* enemyData = (EnemyData*)(0x9A8E9C);
+        u8* kernelLimitScriptIndexes = (u8*)(0x7B76A0);
+        u8* unkPartyStructPtr = (u8*)(0x9A87F4);
+
+        cameraOverrideData = 0xFFFF;
+        deathSentenceFlag = 0;
+        gDamageContextPtr->MPCost = -1;
+
+        if (gDamageContextPtr->commandIndexCopy == CMD_ENEMY_ACTION) {
+            sceneAbilityIndex = getSceneIndexFromActionID(gDamageContextPtr->attackIndexCopy);
+            abilityDataPtr = &(currentSceneAbilities[sceneAbilityIndex]); //This is where the scene ability data is stored
+            gDamageContextPtr->sceneAbilityIndex = sceneAbilityIndex;
+        }
+        else if (gDamageContextPtr->attackIndexCopy >= 128) { //The ability data here is not contained in the kernel
+            if (gDamageContextPtr->attackerID < 3) {
+                characterID = unkPartyStructPtr[16 * gDamageContextPtr->attackerID]; //array access, should figure out these structs
+                activeLimitIDs = (u8*)activePartyStructArray[gDamageContextPtr->attackerID].enabledLimitBytes;
+                for (i32 limitIndex = 0; limitIndex < 3; ++limitIndex) {
+                    relativeLimitIndex = (i8)activeLimitIDs[limitIndex];
+                    if (relativeLimitIndex + 128 == gDamageContextPtr->attackIndexCopy) { //If this is the limit being used
+                        limitAnimationScriptIndex = 0;
+                        for (charLimitArrayIndex = 0; charLimitArrayIndex < 12; ++charLimitArrayIndex) {
+                            fetchedRelativeIndex = getLimitRelativeIndex(characterID, charLimitArrayIndex);
+                            if (fetchedRelativeIndex != 127) {
+                                if (fetchedRelativeIndex == relativeLimitIndex)
+                                    break;
+                                ++limitAnimationScriptIndex;
+                            }
+                        }
+                        gDamageContextPtr->animationScriptID = limitAnimationScriptIndex + 60;
+                        abilityDataPtr = &(activePartyStructArray[gDamageContextPtr->attackerID].enabledLimitData[limitIndex]);
+                        break;
+                    }
+                }
+            }
+        }
+        else { //load abilities which have been loaded from the kernel -- this code can be relocated to load from gContext
+            abilityDataPtr = &(kernelAbilities[gDamageContextPtr->attackIndexCopy]);
+            if (gDamageContextPtr->attackIndexCopy >= 96) {
+                relativeIndex = gDamageContextPtr->attackIndexCopy - 96;
+                if (kernelLimitScriptIndexes[relativeIndex] != 255)
+                    gDamageContextPtr->animationScriptID = kernelLimitScriptIndexes[relativeIndex];
+                gDamageContextPtr->animationBaseOffset = -1;
+            }
+        }
+        if (gDamageContextPtr->commandIndex == CMD_MAGIC && gDamageContextPtr->attackIndexCopy == 54) //death sentence case hardcoded
+            deathSentenceFlag = 1;
+        if ((gDamageContextPtr->animationBaseOffset != -1) && !((gDamageContextPtr->miscActionflags) & 0x400000)) {
+            spellFlags* spellData = &(activePartyStructArray[gDamageContextPtr->attackerID].enabledMagicsData[gDamageContextPtr->animationBaseOffset]);
+            gDamageContextPtr->MPCost = spellData->mpCost;
+            if (spellData->quadCount && spellData->quadEnabled) {
+                spellData->quadCount = spellData->quadCount - 1;
+                gDamageContextPtr->unkDWord5 = spellData->quadEnabled;// quadEnabled?
+                gDamageContextPtr->unkDWord1 = gDamageContextPtr->unkDWord5 + 3;  // numberOfCasts?
+                if (gDamageContextPtr->unkDWord1 > 8) {
+                    gDamageContextPtr->unkDWord1 = 8;
+                }
+                srCreateEvent(2, gDamageContextPtr->attackerID, 21, 6);
+            }
+            else if (gDamageContextPtr->commandIndexCopy == CMD_SUMMON) {
+                if (spellData->allCount) { //if yo ucan still use the summon
+                    if (spellData->allCount != 255) {
+                        spellData->allCount = spellData->allCount - 1;
+                        srCreateEvent(2, gDamageContextPtr->attackerID, 21, 4);
+                    }
+                }
+                else {
+                    gDamageContextPtr->displayString = 121; //Probably displays "Summon Power is all used up"
+                }
+            }
+            else if (gDamageContextPtr->miscActionflags & 0x200) { //Handle the all case
+                if (spellData->allCount) {
+                    if (spellData->allCount != 255) {
+                        spellData->allCount = spellData->allCount - 1;
+                        srCreateEvent(2, gDamageContextPtr->attackerID, 21, 2);
+                    }
+                }
+                else if (abilityDataPtr->targetingFlags & 8) {
+                    gDamageContextPtr->miscActionflags |= 0x100000u;
+                }
+            }
+            if ((executingAction.entryPriority >= 5) && !(gDamageContextPtr->miscActionflags & 0x400000)) //priority 5 and 6 actions? what are those
+                gDamageContextPtr->addedCutMPHPAbsorbByte = spellData->actorPropertiesMask;
+        }
+        if (deathSentenceFlag)
+        {
+            gDamageContextPtr->animationScriptID = 52;
+        }
+        else if (gDamageContextPtr->attackerID >= 4) {
+            auto actingEnemyRecord =  enemyData[gDamageContextPtr->enemySceneIndex]; //Finds the "formation data" for the current actor
+            for (enemyActionIndex = 0; enemyActionIndex < 16; ++enemyActionIndex) {
+                if (gDamageContextPtr->attackIndexCopy == actingEnemyRecord.attackSceneIDs[enemyActionIndex]) { //offset into the actual actor IDs
+                    gDamageContextPtr->animationScriptID = actingEnemyRecord.attackAnimScripts[enemyActionIndex]; //offset into the animation script indexes for this model
+                    cameraOverrideData = actingEnemyRecord.attackCameraIDs[enemyActionIndex];
+                    break;
+                }
+            }
+        }
+        if (gDamageContextPtr->MPCost < 0)
+            gDamageContextPtr->MPCost = abilityDataPtr->MPCost;
+        if (executingAction.entryPriority == 3 || gDamageContextPtr->miscActionflags & 0x400000) //This is triggered by mime
+            gDamageContextPtr->MPCost = 0;
+        gDamageContextPtr->abilityHitRate = abilityDataPtr->abilityHitRate;
+        gDamageContextPtr->damageFormulaID = abilityDataPtr->damageFormula;
+        if (abilityDataPtr->elementMask == 0xFFFF) 
+            elementMask = 0;
+        else
+            elementMask = abilityDataPtr->elementMask;
+        gDamageContextPtr->attackElementsMask = elementMask;
+        gDamageContextPtr->abilityPower = abilityDataPtr->attackPower;
+        gDamageContextPtr->targetReactionAnimation = abilityDataPtr->targetReactionID;
+        if (gDamageContextPtr->abilityTargetingFlags == 255)
+            gDamageContextPtr->abilityTargetingFlags = abilityDataPtr->targetingFlags;
+        if (gDamageContextPtr->commandIndexCopy == CMD_LIMIT)
+            cameraOverrideData = (((*(u16*)0x9AB0CC) & 8) != 0) ? abilityDataPtr->cameraMovementMultiple : abilityDataPtr->cameraMovementSingle;
+        if (cameraOverrideData == 0xFFFF) {
+            gDamageContextPtr->cameraDataSingle = abilityDataPtr->cameraMovementSingle;
+            gDamageContextPtr->cameraDataMultiple = abilityDataPtr->cameraMovementMultiple;
+        }
+        else {
+            gDamageContextPtr->cameraDataSingle = cameraOverrideData;
+            gDamageContextPtr->cameraDataMultiple = cameraOverrideData;
+        }
+        if (abilityDataPtr->impactEffectID!= 255)
+            gDamageContextPtr->impactEffectID = abilityDataPtr->impactEffectID;
+        gDamageContextPtr->animationEffectID = abilityDataPtr->animationEffectID;
+        gDamageContextPtr->specialAbilityFlags = abilityDataPtr->specialAttackFlags;
+        gDamageContextPtr->impactSound = abilityDataPtr->impactSoundID;
+        gDamageContextPtr->critAtkSound = abilityDataPtr->impactSoundID;
+        gDamageContextPtr->missAtkSound = abilityDataPtr->impactSoundID;
+        if (!((gDamageContextPtr->specialAbilityFlags) & 4) && gAiActorVariables[gDamageContextPtr->attackerID].statusMask & 0x4000000)
+            gDamageContextPtr->abilityHitRate >>= 1; //(half hit chance)
+        statusMasksFromAbility(abilityDataPtr->statusInfictType, abilityDataPtr->statusMask);
+        if (deathSentenceFlag)
+            gAiActorVariables[gDamageContextPtr->attackerID].statusMask &= 0xFFDFFFFF;
+        return copyAdditionalEffects(abilityDataPtr->additionalEffect, abilityDataPtr->additionalEffectModifier);
+}

--- a/src/battle/battle_context.cpp
+++ b/src/battle/battle_context.cpp
@@ -1,7 +1,7 @@
 #include "battle_context.h"
 #include "../impl.h"
 
-void setContextFromAbility() {
+void srLoadAbilityData() {
         i32 sceneAbilityIndex; 
         i32 enemyActionIndex;
         u16 elementMask;
@@ -33,7 +33,7 @@ void setContextFromAbility() {
             auto enemyAttack = gContext.enemyAttacks.get_element(attackID);
             abilityDataPtr = &(gContext.enemyAttacks.get_element(attackID).attackData);
             currentSceneAbilities[0] = enemyAttack.attackData;
-            strcpy(currentSceneAbilityNames, enemyAttack.attackName.str()); //We will need to verify that this actually works, strcpy might expect null termination and buffer overrun here
+            memcpy((void*)currentSceneAbilityNames, (void*)enemyAttack.attackName.str(), enemyAttack.attackName.size()); //We will need to verify that this actually works, strcpy might expect null termination and buffer overrun here
             *currentSceneAbilityIDs = enemyAttack.attackID;
             gDamageContextPtr->sceneAbilityIndex = 0;
         }

--- a/src/battle/battle_context.cpp
+++ b/src/battle/battle_context.cpp
@@ -28,7 +28,9 @@ void srLoadAbilityData() {
         deathSentenceFlag = 0;
         gDamageContextPtr->MPCost = -1;
         srLogWrite("attempting to load ability data");
-        srLogWrite("command index being exeucted: %i", gDamageContextPtr->commandIndexCopy);
+        srLogWrite("command index being executed: %i", gDamageContextPtr->commandIndex);
+        srLogWrite("attack index being executed: %i", gDamageContextPtr->attackIndex);
+        srLogWrite("command index being executed: %i", gDamageContextPtr->commandIndexCopy);
         srLogWrite("enemy action command index %i", CMD_ENEMY_ACTION);
         srLogWrite("action index being executed: %i", gDamageContextPtr->attackIndexCopy);
         srLogWrite("actor ID: %i", gDamageContextPtr->attackerID);

--- a/src/battle/battle_context.h
+++ b/src/battle/battle_context.h
@@ -1,0 +1,8 @@
+#ifndef BATTLE_CONTEXT_H
+#define BATTLE_CONTEXT_H
+
+#include <SisterRay/SisterRay.h>
+
+void setCurrentActionAbilityData();
+
+#endif

--- a/src/battle/battle_context.h
+++ b/src/battle/battle_context.h
@@ -3,7 +3,7 @@
 
 #include <SisterRay/SisterRay.h>
 
-void setContextFromAbility();
+void srLoadAbilityData();
 void setStatusInflictionData(i32 statusInflictionByte, i32 inflictedStatusMask);
 
 #endif

--- a/src/battle/battle_context.h
+++ b/src/battle/battle_context.h
@@ -3,6 +3,7 @@
 
 #include <SisterRay/SisterRay.h>
 
-void setCurrentActionAbilityData();
+void setContextFromAbility();
+void setStatusInflictionData(i32 statusInflictionByte, i32 inflictedStatusMask);
 
 #endif

--- a/src/battle/enemies.cpp
+++ b/src/battle/enemies.cpp
@@ -1,0 +1,1 @@
+#include "enemies.h"

--- a/src/battle/enemies.h
+++ b/src/battle/enemies.h
@@ -1,0 +1,18 @@
+#ifndef ENEMIES_H
+#define ENEMIES_H
+
+#include "../sr_named_registry.h"
+#include "ai_scripts.h"
+
+/*The following registries contain enemy data and AI scripts indexed by the absolute ID of the enemy*/
+class SrEnemyRegistry : public SrNamedResourceRegistry<EnemyData, std::string> {
+public:
+    SrEnemyRegistry() : SrNamedResourceRegistry<EnemyData, std::string>() {}
+};
+
+class SrEnemyAIRegistry: public SrNamedResourceRegistry<BattleAIData, std::string> {
+public:
+    SrEnemyAIRegistry() : SrNamedResourceRegistry<BattleAIData, std::string>() {}
+};
+
+#endif

--- a/src/battle/enemies.h
+++ b/src/battle/enemies.h
@@ -4,15 +4,28 @@
 #include "../sr_named_registry.h"
 #include "ai_scripts.h"
 
+typedef struct {
+    EnemyData enemyData;
+    u16 modelID;
+    BattleAIData enemyAI;
+} SrEnemyData;
+
+typedef struct {
+    AttackData attackData;
+    u16 attackID;
+    std::string attackName;
+} EnemyAttack;
+
 /*The following registries contain enemy data and AI scripts indexed by the absolute ID of the enemy*/
-class SrEnemyRegistry : public SrNamedResourceRegistry<EnemyData, std::string> {
+class SrEnemyRegistry : public SrNamedResourceRegistry<SrEnemyData, std::string> {
 public:
-    SrEnemyRegistry() : SrNamedResourceRegistry<EnemyData, std::string>() {}
+    SrEnemyRegistry() : SrNamedResourceRegistry<SrEnemyData, std::string>() {}
 };
 
-class SrEnemyAIRegistry: public SrNamedResourceRegistry<BattleAIData, std::string> {
+class SrEnemyAttackRegistry : public SrNamedResourceRegistry<EnemyAttack, std::string> {
 public:
-    SrEnemyAIRegistry() : SrNamedResourceRegistry<BattleAIData, std::string>() {}
+    SrEnemyAttackRegistry() : SrNamedResourceRegistry<EnemyAttack, std::string>() {}
 };
+
 
 #endif

--- a/src/battle/enemies.h
+++ b/src/battle/enemies.h
@@ -3,6 +3,7 @@
 
 #include "../sr_named_registry.h"
 #include "ai_scripts.h"
+#include "../EncodedString.h"
 
 typedef struct {
     EnemyData enemyData;
@@ -13,7 +14,7 @@ typedef struct {
 typedef struct {
     AttackData attackData;
     u16 attackID;
-    std::string attackName;
+    EncodedString attackName;
 } EnemyAttack;
 
 /*The following registries contain enemy data and AI scripts indexed by the absolute ID of the enemy*/

--- a/src/battle/formations.h
+++ b/src/battle/formations.h
@@ -5,51 +5,14 @@
 #include "ai_scripts.h"
 
 typedef struct {
-    u16 EnemyIds[3];
-    u16 terminator; //always 0xFF
-} FormationEnemies;
+    std::string uniqueIDs[3];
+} FormationEnemyIDs;
 
 typedef struct {
-    u16 battleLocation;
-    u16 nextFormationID;
-    u16 escapeCounter;
-    u16 align;
-    u16 battleArenaCandidates[4]; //one of the four formation entries listed will be be fetched for the next ID
-    u16 battleFlags;
-    u8 battleType; //side attack, etc
-    u8 initCameraID;
-} FormationSetup;
-
-typedef struct {
-    u16 xCoordinate;
-    u16 yCoordinate;
-    u16 zCoordinate;
-    u16 xVector;
-    u16 yVector;
-    u16 zVector;
-} CameraData;
-
-typedef struct {
-    CameraData mainCamera;
-    CameraData animationCams[2];
-    u8 padding[12]; //always 0xFFFF -- we might be able to extend/relocate this buffer to enable more camera positions for more dynamic battles
-} FormationCamera;
-
-typedef struct {
-    u16 enemyID; //This is an index into SrEnemyRegistry -- 0xFFFF by default
-    u16 xCoordinate;
-    u16 yCoordinate;
-    u16 zCoordinate;
-    u16 actorRow;
-    u16 coverFlags;
-    u32 initialStateFlags;
-} FormationActorData;
-
-typedef struct {
-    FormationEnemies formationEnemyIDs;
+    FormationEnemyIDs FormationEnemyIDs; //this is the name in gContexts enemy registry
     FormationSetup formationSetup;
     FormationCamera formationCamera;
-    FormationActorData formationUnits[6];
+    FormationActorDataArray formationActorDataArray;
     BattleAIData formationAI;
 } FormationData;
 

--- a/src/battle/formations.h
+++ b/src/battle/formations.h
@@ -1,0 +1,62 @@
+#ifndef FORMATIONS_H
+#define FORMATIONS_H
+
+#include "../sr_named_registry.h"
+#include "ai_scripts.h"
+
+typedef struct {
+    u16 EnemyIds[3];
+    u16 terminator; //always 0xFF
+} FormationEnemies;
+
+typedef struct {
+    u16 battleLocation;
+    u16 nextFormationID;
+    u16 escapeCounter;
+    u16 align;
+    u16 battleArenaCandidates[4]; //one of the four formation entries listed will be be fetched for the next ID
+    u16 battleFlags;
+    u8 battleType; //side attack, etc
+    u8 initCameraID;
+} FormationSetup;
+
+typedef struct {
+    u16 xCoordinate;
+    u16 yCoordinate;
+    u16 zCoordinate;
+    u16 xVector;
+    u16 yVector;
+    u16 zVector;
+} CameraData;
+
+typedef struct {
+    CameraData mainCamera;
+    CameraData animationCams[2];
+    u8 padding[12]; //always 0xFFFF -- we might be able to extend/relocate this buffer to enable more camera positions for more dynamic battles
+} FormationCamera;
+
+typedef struct {
+    u16 enemyID; //This is an index into SrEnemyRegistry -- 0xFFFF by default
+    u16 xCoordinate;
+    u16 yCoordinate;
+    u16 zCoordinate;
+    u16 actorRow;
+    u16 coverFlags;
+    u32 initialStateFlags;
+} FormationActorData;
+
+typedef struct {
+    FormationEnemies formationEnemyIDs;
+    FormationSetup formationSetup;
+    FormationCamera formationCamera;
+    FormationActorData formationUnits[6];
+    BattleAIData formationAI;
+} FormationData;
+
+/*The following registries contain formation indexed data used by the battle module*/
+class SrFormationRegistry : public SrNamedResourceRegistry<FormationData, std::string> {
+public:
+    SrFormationRegistry() : SrNamedResourceRegistry<FormationData, std::string>() {}
+};
+
+#endif

--- a/src/gamedata/armor.cpp
+++ b/src/gamedata/armor.cpp
@@ -8,12 +8,12 @@ SISTERRAY_API ArmorData getArmor(u16 itemID) {
     return gContext.armors.get_resource(itemID);
 }
 
-SISTERRAY_API void setArmorData(ArmorData data, u16 itemID) {
-    gContext.armors.update_resource(itemID, data);
+SISTERRAY_API void setArmorData(ArmorData attackData, u16 itemID) {
+    gContext.armors.update_resource(itemID, attackData);
 }
 
-SISTERRAY_API void addArmor(ArmorData data, char* name) {
-    gContext.armors.add_element(std::string(name), data);
+SISTERRAY_API void addArmor(ArmorData attackData, char* name) {
+    gContext.armors.add_element(std::string(name), attackData);
 }
 
 static const u32 kPatchStructBase[] = {

--- a/src/gamedata/game_data_interface.h
+++ b/src/gamedata/game_data_interface.h
@@ -4,23 +4,23 @@
 #include <SisterRay/SisterRay.h>
 
 SISTERRAY_API WeaponData getWeapon(u16 itemID);
-SISTERRAY_API void setWeaponData(WeaponData data, u16 itemID);
-SISTERRAY_API void addWeapon(WeaponData data, char* name);
+SISTERRAY_API void setWeaponData(WeaponData attackData, u16 itemID);
+SISTERRAY_API void addWeapon(WeaponData attackData, char* name);
 
 SISTERRAY_API ArmorData getArmor(u16 itemID);
-SISTERRAY_API void setArmorData(ArmorData data, u16 itemID);
-SISTERRAY_API void addArmor(ArmorData data, char* name);
+SISTERRAY_API void setArmorData(ArmorData attackData, u16 itemID);
+SISTERRAY_API void addArmor(ArmorData attackData, char* name);
 
 SISTERRAY_API AccessoryData getAccessory(u16 itemID);
-SISTERRAY_API void setAccessoryData(AccessoryData data, u16 itemID);
-SISTERRAY_API void addAccessory(AccessoryData data, char* name);
+SISTERRAY_API void setAccessoryData(AccessoryData attackData, u16 itemID);
+SISTERRAY_API void addAccessory(AccessoryData attackData, char* name);
 
 SISTERRAY_API ItemData getItem(u16 itemID);
-SISTERRAY_API void setItemData(ItemData data, u16 itemID);
-SISTERRAY_API void addItem(ItemData data, char* name);
+SISTERRAY_API void setItemData(ItemData attackData, u16 itemID);
+SISTERRAY_API void addItem(ItemData attackData, char* name);
 
 SISTERRAY_API MateriaData getMateria(u16 itemID);
-SISTERRAY_API void setMateriaData(MateriaData data, u16 itemID);
-SISTERRAY_API void addMateria(MateriaData data, char* name);
+SISTERRAY_API void setMateriaData(MateriaData attackData, u16 itemID);
+SISTERRAY_API void addMateria(MateriaData attackData, char* name);
 
 #endif

--- a/src/gamedata/items.cpp
+++ b/src/gamedata/items.cpp
@@ -81,7 +81,7 @@ void createOnUseItemData(u16 hp_heal_amount, u16 mp_heal_amount,
         requires_target
     };
 
-    gContext.item_on_use_data.add_resource(itemData);
+    gContext.itemOnUseData.add_resource(itemData);
 
 }
 
@@ -100,7 +100,7 @@ bool character_can_use_item(u8 character_ID, u16 item_id) {
     u16 restriction_mask;
     switch(item_type) {
     case 0: {
-        restriction_mask = gContext.item_on_use_data.get_resource(item_id).characterRestrictionMask;
+        restriction_mask = gContext.itemOnUseData.get_resource(item_id).characterRestrictionMask;
         if (restriction_mask & (1 << (character_ID))) {
             return true;
         }

--- a/src/gzip.cpp
+++ b/src/gzip.cpp
@@ -1,0 +1,87 @@
+#include "gzip.h"
+#include <memory>
+#define CHUNK 4096
+
+SISTERRAY_API void srGzipStreamOpen(SrGzipStream* stream, const u8* src, size_t srcSize, size_t dstSize) {
+    memset(stream, 0, sizeof(*stream));
+    stream->inBuffer = (char*)malloc(CHUNK);
+    stream->outBuffer = (char*)malloc(CHUNK);
+    stream->deflatedSize = srcSize;
+    stream->inflatedSize = dstSize;
+    stream->zstream.zalloc = Z_NULL;
+    stream->zstream.zfree = Z_NULL;
+    stream->zstream.opaque = Z_NULL;
+    stream->zstream.avail_in = CHUNK;
+    stream->src = src;
+    if (stream->zstream.avail_in > stream->deflatedSize)
+        stream->zstream.avail_in = stream->deflatedSize;
+    stream->zstream.next_in = (Bytef *)stream->inBuffer;
+    stream->cursor = stream->zstream.avail_in;
+    memcpy(stream->inBuffer, src, stream->zstream.avail_in); //read in the first section of the file for decompression according to avail-in
+    stream->zstream.avail_out = CHUNK;
+    stream->zstream.next_out = (Bytef *)stream->outBuffer;
+    stream->outStart = stream->outBuffer;
+    inflateInit2(&stream->zstream, 31);
+}
+
+/*decompress gzipped data in buffer src with size srcSize into buffer dst according to readSize; dst is size of extracted buffer*/
+SISTERRAY_API size_t srGzipInflateCpy(const u8* src, size_t srcSize, u8* dst, size_t dstSize) {
+    /*Initialize the stream object used for decompression*/
+    SrGzipStream stream = SrGzipStream();
+    srGzipStreamOpen(&stream, src, srcSize, dstSize);
+    auto readLength = srGzipRead(stream, dst, dstSize);
+    return readLength;
+}
+
+size_t srGzipRead(SrGzipStream& stream, u8* dst, size_t readSize) {
+    size_t readLength;
+    size_t avail;
+    size_t remain;
+
+    readLength = 0;
+    remain = readSize;
+
+    if (readSize == 0)
+        return 0;
+
+    for (;;) {
+        /* If data is present in the output buffer, use it */
+        if (stream.zstream.avail_out < CHUNK) {
+            avail = CHUNK - stream.zstream.avail_out;
+            if (remain < avail)
+                avail = remain;
+            memcpy(dst + readLength, stream.outStart, avail);
+            readLength += avail;
+            remain -= avail;
+            stream.outStart += avail;
+            stream.zstream.avail_out += avail;
+
+            if (remain == 0)
+                break;
+        }
+
+        /* Output buffer is empty, reset it */
+        stream.outStart = stream.outBuffer;
+        stream.zstream.next_out = (Bytef*)stream.outBuffer;
+        stream.zstream.avail_out = CHUNK;
+
+        if (stream.zstream.avail_in == 0) {
+            /* Input buffer is empty, refill it */
+            avail = CHUNK;
+            if (stream.cursor + avail > stream.deflatedSize)
+                avail = stream.deflatedSize - stream.cursor;
+
+            /* If all buffers are empty, then we reached EOF */
+            if (avail == 0)
+                break;
+
+            memcpy(stream.inBuffer, stream.src, avail);
+            stream.zstream.avail_in = avail;
+            stream.zstream.next_in = (Bytef*)stream.inBuffer;
+            stream.cursor += avail;
+        }
+
+        inflate(&stream.zstream, Z_NO_FLUSH);
+    }
+    return readLength;
+}

--- a/src/gzip.h
+++ b/src/gzip.h
@@ -1,0 +1,24 @@
+#ifndef GZIP_H
+#define GZIP_H
+
+#include <stdio.h>
+#include <zlib.h>
+#include <SisterRay/SisterRay.h>
+
+typedef struct {
+    u16         deflatedSize; // compressed size
+    u16         inflatedSize; // uncompressed size
+    z_stream    zstream;
+    const u8*   src;
+    char*       inBuffer;
+    char*       outBuffer;
+    char*       outStart;
+    u32         cursor;
+} SrGzipStream;
+
+SISTERRAY_API void srGzipStreamOpen(SrGzipStream* stream, const u8* src, size_t srcSize, size_t dstSize);
+SISTERRAY_API size_t srGzipInflateCpy(const u8* src, size_t srcSize, u8* dst, size_t dstSize);
+size_t srGzipRead(SrGzipStream& stream, u8* dst, size_t readSize);
+u32 getFileSize(const char* filename);
+
+#endif

--- a/src/impl.h
+++ b/src/impl.h
@@ -24,12 +24,15 @@ extern "C" {
 #include "gamedata/weapons.h"
 #include "gamedata/armor.h"
 #include "gamedata/accessory.h"
+#include "battle/formations.h"
+#include "battle/enemies.h"
 #include "inventories/inventory.h"
 #include "inventories/battle_inventory.h"
 #include "inventories/materia_inventory.h"
 #include "usable_item_handlers.h"
 #include "events/event_bus.h"
 #include "string_registry.h"
+#include "party/characters.h"
 #include "menus/menu.h"
 #include <map>
 #include <memory>
@@ -46,14 +49,18 @@ typedef struct {
     SrAccessoryRegistry                 accessories;
     SrMateriaRegistry                   materias;
     std::unique_ptr<SrItemInventory>    inventory;
-    std::unique_ptr<SrBattleInventory>  battle_inventory;
-    std::unique_ptr<SrMateriaInventory> materia_inventory;
+    std::unique_ptr<SrBattleInventory>  battleInventory;
+    std::unique_ptr<SrMateriaInventory> materiaInventory;
     SrGearViewData                      gearViewData;
     SrItemTypeRegistry                  itemTypeData;
-    srOnUseCallbackRegistry             on_use_handlers; /*Registry of function pointers for using items*/
+    srOnUseCallbackRegistry             onUseHandlers; /*Registry of function pointers for using items*/
     srNoTargetCallbackRegistry          untargeted_handlers;
-    SrOnUseItemDataRegistry             item_on_use_data;
-    SrGameStrings                       game_strings;
+    SrOnUseItemDataRegistry             itemOnUseData;
+    SrCharacterRegistry                 characters;
+    SrFormationRegistry                 formations;
+    SrEnemyRegistry                     enemies;
+    SrEnemyAttackRegistry               enemyAttacks;
+    SrGameStrings                       gameStrings;
     MenuRegistry                        menuWidgets;
     EventBus                            eventBus;
 } SrContext;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -144,6 +144,8 @@ static void Init(void)
     mogReplaceFunction(LOAD_FORMATION_HANDLER, &srLoadBattleFormation);
     mogReplaceFunction(EXECUTE_AI_SCRIPT_HANDLER, &srExecuteAIScript);
     mogReplaceFunction(EXECUTE_FORMATION_SCRIPT_HANDLER, &srExecuteFormationScripts);
+    mogReplaceFunction(ENQUEUE_SCRIPT_ACTION, &enqueueScriptAction);
+    mogReplaceFunction(TRANSFORM_ENEMY_COMMAND, &transformEnemyCommand);
     LoadMods();
     MessageBoxA(NULL, "Sister ray at 100% power", "SisterRay", 0);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -113,7 +113,6 @@ static void srLoadKernelBin(void)
 
 static void Init(void)
 {
-    MessageBoxA(NULL, "Sister ray at 100% power", "SisterRay", 0);
     initLog();
     srInitLua();
     initFunctionRegistry();
@@ -145,6 +144,7 @@ static void Init(void)
     mogReplaceFunction(LOAD_FORMATION_HANDLER, &loadBattleFormation);
     mogReplaceFunction(EXECUTE_AI_SCRIPT_HANDLER, &srExecuteAIScript);
     LoadMods();
+    MessageBoxA(NULL, "Sister ray at 100% power", "SisterRay", 0);
 
     /* Init RNG */
     srand((unsigned int)time(nullptr));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -11,6 +11,8 @@
 #include "menus/battle_menu.h"
 #include "menus/equip_menu/equip_menu.h"
 #include "menus/equip_menu//equip_menu_callbacks.h"
+#include "battle/battle.h"
+#include "battle/battle_context.h"
 
 
 SrContext gContext;
@@ -18,7 +20,7 @@ SrContext gContext;
 static const SrKernelStreamHandler kKernelBinHandlers[9] = {
     NULL,
     NULL,
-    NULL,
+    initCharacterData,
     NULL,
     initItems,
     init_weapon,
@@ -35,24 +37,24 @@ struct Kernel2Entry {
 static void srLoadKernel2Bin(void)
 {
     static const Kernel2Entry kKernel2Entries[] = {
-        { &gContext.game_strings.command_descriptions,   0x20  },
-        { &gContext.game_strings.magic_descriptions,     0x100 },
-        { &gContext.game_strings.item_descriptions,      0x80  },
-        { &gContext.game_strings.weapon_descriptions,    0x80  },
-        { &gContext.game_strings.armor_descriptions,     0x20  },
-        { &gContext.game_strings.accessory_descriptions, 0x20  },
-        { &gContext.game_strings.materia_descriptions,   0x60  },
-        { &gContext.game_strings.key_item_descriptions,  0x40  },
-        { &gContext.game_strings.command_names,          0x20  },
-        { &gContext.game_strings.magic_names,            0x100 },
-        { &gContext.game_strings.item_names,             0x80  },
-        { &gContext.game_strings.weapon_names,           0x80  },
-        { &gContext.game_strings.armor_names,            0x20  },
-        { &gContext.game_strings.accessory_names,        0x20  },
-        { &gContext.game_strings.materia_names,          0x60  },
-        { &gContext.game_strings.key_item_names,         0x40  },
-        { &gContext.game_strings.battle_texts,           0x80  },
-        { &gContext.game_strings.summon_attack_names,    0x10  },
+        { &gContext.gameStrings.command_descriptions,   0x20  },
+        { &gContext.gameStrings.magic_descriptions,     0x100 },
+        { &gContext.gameStrings.item_descriptions,      0x80  },
+        { &gContext.gameStrings.weapon_descriptions,    0x80  },
+        { &gContext.gameStrings.armor_descriptions,     0x20  },
+        { &gContext.gameStrings.accessory_descriptions, 0x20  },
+        { &gContext.gameStrings.materia_descriptions,   0x60  },
+        { &gContext.gameStrings.key_item_descriptions,  0x40  },
+        { &gContext.gameStrings.command_names,          0x20  },
+        { &gContext.gameStrings.magic_names,            0x100 },
+        { &gContext.gameStrings.item_names,             0x80  },
+        { &gContext.gameStrings.weapon_names,           0x80  },
+        { &gContext.gameStrings.armor_names,            0x20  },
+        { &gContext.gameStrings.accessory_names,        0x20  },
+        { &gContext.gameStrings.materia_names,          0x60  },
+        { &gContext.gameStrings.key_item_names,         0x40  },
+        { &gContext.gameStrings.battle_texts,           0x80  },
+        { &gContext.gameStrings.summon_attack_names,    0x10  },
     };
 
     u16 offsetTable[0x100];
@@ -126,18 +128,22 @@ static void Init(void)
     initOnUseCallbackRegistry();
     initNoTargetCallbackRegistry();
     testFillInventory();
+    initFormationsRegistries();; //initialize all data from the scene.bin
     //Register base callbacks
     registerEquipMenuListeners();
     initializeEquipMenu();
     registerInventoryMenuListeners();
     initializeInventoryMenu();
-    //End Register base callbacks
+    //End Register base callbacks, begin registering new handlers
     mogReplaceFunction(MAIN_INVENTORY_HANDLER, &inventoryMenuUpdateHandler); //add our new menu handler
     mogReplaceFunction(INIT_BATTLE_INVENTORY, &setupBattleInventory);
     mogReplaceFunction(RENDER_BATTLE_ITEM_MENU, &renderBattleItemView);
     mogReplaceFunction(INIT_BATTLE_ITEM_MENU_CURSOR, &initializeBattleItemMenuCursor);
     mogReplaceFunction(BATTLE_ITEM_MENU_INPUT_HANDLER, &battleItemMenuInputHandler);
     mogReplaceFunction(EQUIP_MENU_UPDATE_HANDLER, &equipMenuUpdateHandler);
+    mogReplaceFunction(LOAD_ABILITY_DATA_HANDLER, &setContextFromAbility);
+    mogReplaceFunction(LOAD_FORMATION_HANDLER, &loadBattleFormation);
+    mogReplaceFunction(EXECUTE_AI_SCRIPT_HANDLER, &srExecuteAIScript);
     LoadMods();
 
     /* Init RNG */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -140,9 +140,10 @@ static void Init(void)
     mogReplaceFunction(INIT_BATTLE_ITEM_MENU_CURSOR, &initializeBattleItemMenuCursor);
     mogReplaceFunction(BATTLE_ITEM_MENU_INPUT_HANDLER, &battleItemMenuInputHandler);
     mogReplaceFunction(EQUIP_MENU_UPDATE_HANDLER, &equipMenuUpdateHandler);
-    mogReplaceFunction(LOAD_ABILITY_DATA_HANDLER, &setContextFromAbility);
-    mogReplaceFunction(LOAD_FORMATION_HANDLER, &loadBattleFormation);
+    mogReplaceFunction(LOAD_ABILITY_DATA_HANDLER, &srLoadAbilityData);
+    mogReplaceFunction(LOAD_FORMATION_HANDLER, &srLoadBattleFormation);
     mogReplaceFunction(EXECUTE_AI_SCRIPT_HANDLER, &srExecuteAIScript);
+    mogReplaceFunction(EXECUTE_FORMATION_SCRIPT_HANDLER, &srExecuteFormationScripts);
     LoadMods();
     MessageBoxA(NULL, "Sister ray at 100% power", "SisterRay", 0);
 

--- a/src/inventories/battle_inventory.cpp
+++ b/src/inventories/battle_inventory.cpp
@@ -24,6 +24,6 @@ void SrBattleInventory::setSlotsInUse(u16 slotsInUse) {
 
 SISTERRAY_API void initBattleInventory()
 {
-    gContext.battle_inventory = std::make_unique<SrBattleInventory>(BATTLE_INVENTORY_SIZE);
-    srLogWrite("sister ray: in_battle inventory initialized with capacity: %lu", (unsigned long)gContext.battle_inventory->current_capacity());
+    gContext.battleInventory = std::make_unique<SrBattleInventory>(BATTLE_INVENTORY_SIZE);
+    srLogWrite("sister ray: in_battle inventory initialized with capacity: %lu", (unsigned long)gContext.battleInventory->current_capacity());
 }

--- a/src/inventories/inventory_functions.cpp
+++ b/src/inventories/inventory_functions.cpp
@@ -24,10 +24,10 @@ SISTERRAY_API u8 setupBattleInventory() {
                 (u8)restrictionMask,
                 0
             };
-            gContext.battle_inventory->update_resource(inventory_index, entry);
+            gContext.battleInventory->update_resource(inventory_index, entry);
             totalItemsCount++;
         }
     }
-    gContext.battle_inventory->setSlotsInUse(totalItemsCount);
+    gContext.battleInventory->setSlotsInUse(totalItemsCount);
     return (u8)totalItemsCount; //The code expects this to return the "current item count" as a byte, we are making sure this isn't actually read in the code
 }

--- a/src/inventories/inventory_utils.cpp
+++ b/src/inventories/inventory_utils.cpp
@@ -32,7 +32,7 @@ u16 getCharacterRestrictionMask(u16 item_id) {
     u16 restriction_mask;
     switch (item_type) {
     case 0: {
-        restriction_mask = gContext.item_on_use_data.get_resource(relative_id).characterRestrictionMask;
+        restriction_mask = gContext.itemOnUseData.get_resource(relative_id).characterRestrictionMask;
         break;
     }
     case 1: {

--- a/src/inventories/materia_inventory.cpp
+++ b/src/inventories/materia_inventory.cpp
@@ -33,6 +33,6 @@ void SrMateriaInventory::removeFromMateriaInventory(u8* inventory_index) {
 }
 
 SISTERRAY_API void initMateriaInventory() {
-    gContext.materia_inventory = std::make_unique<SrMateriaInventory>(MATERIA_INVENTORY_SIZE);
+    gContext.materiaInventory = std::make_unique<SrMateriaInventory>(MATERIA_INVENTORY_SIZE);
     srLogWrite("sister ray: inventory initialized with capacity: %lu", (unsigned long)gContext.inventory->current_capacity());
 }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -40,7 +40,7 @@ SISTERRAY_API void srKernelStreamSkip(SrKernelStream* stream)
     fseek(stream->file, stream->deflatedSize - stream->cursor, SEEK_CUR);
 }
 
-SISTERRAY_API size_t srKernelStreamRead(SrKernelStream* stream, void* dst, size_t size)
+SISTERRAY_API size_t srKernelStreamRead(SrKernelStream* stream, void* dst, size_t readSize)
 {
     char* buf;
     size_t readLength;
@@ -49,9 +49,9 @@ SISTERRAY_API size_t srKernelStreamRead(SrKernelStream* stream, void* dst, size_
 
     buf = (char*)dst;
     readLength = 0;
-    remain = size;
+    remain = readSize;
 
-    if (size == 0)
+    if (readSize == 0)
         return 0;
 
     for (;;)

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -5,9 +5,11 @@
 #include <zlib.h>
 #include <SisterRay/SisterRay.h>
 
+/*TODO refactor this stuff to use the new gzip.h api*/
+
 typedef struct {
-    u16         deflatedSize;
-    u16         inflatedSize;
+    u16         deflatedSize; // compressed size
+    u16         inflatedSize; // uncompressed size
     u16         type;
     FILE*       file;
     z_stream    zstream;

--- a/src/lua/item.cpp
+++ b/src/lua/item.cpp
@@ -6,7 +6,7 @@ static int itemName(lua_State* L)
     u16 itemID;
 
     itemID = *((u16*)lua_touserdata(L, 1));
-    lua_pushstring(L, gContext.game_strings.item_names.get_unicode_string(itemID));
+    lua_pushstring(L, gContext.gameStrings.item_names.get_unicode_string(itemID));
     return 1;
 }
 
@@ -15,7 +15,7 @@ static int itemSetName(lua_State* L)
     u16 itemID;
 
     itemID = *((u16*)lua_touserdata(L, 1));
-    gContext.game_strings.item_names.set_unicode_string(itemID, luaL_checkstring(L, 3));
+    gContext.gameStrings.item_names.set_unicode_string(itemID, luaL_checkstring(L, 3));
     return 0;
 }
 

--- a/src/menus/battle_menu.cpp
+++ b/src/menus/battle_menu.cpp
@@ -18,7 +18,7 @@ SISTERRAY_API u32* initializeBattleItemMenuCursor() {
     cursorContextPtr->viewColumnBound = 1;
     cursorContextPtr->viewRowBound = 3;
     cursorContextPtr->maxColumnBound = 1;
-    cursorContextPtr->maxRowBound = gContext.battle_inventory->slots_in_use; //max number of cursor updates "down"
+    cursorContextPtr->maxRowBound = gContext.battleInventory->slots_in_use; //max number of cursor updates "down"
     cursorContextPtr->ninth_dword = 0;
     cursorContextPtr->tenth_dword = 0;
     cursorContextPtr->eleventh_dword = 2;
@@ -41,10 +41,10 @@ SISTERRAY_API i32 renderBattleItemView() {
     u16 renderContextStruct[7];
 
     cursorContextArray = (CursorContext*)(dword_DC20D8 + 448 * (*ACTIVE_MENU_OWNER_PARTY_INDEX)); //In battle each actor has their own array of menu context structures
-    if (gContext.battle_inventory->slots_in_use > 3)
+    if (gContext.battleInventory->slots_in_use > 3)
     {
         renderContextStruct[0] = (u16)3;           // items_visible
-        renderContextStruct[1] = (u16)gContext.battle_inventory->slots_in_use;;// set the current items visible
+        renderContextStruct[1] = (u16)gContext.battleInventory->slots_in_use;;// set the current items visible
         renderContextStruct[2] = (u16)(cursorContextArray[0].baseRowIndex); // base row byte
         renderContextStruct[3] = (u16)614;
         renderContextStruct[4] = (u16)354;
@@ -63,10 +63,10 @@ SISTERRAY_API i32 renderBattleItemView() {
     for (int visibleRow = 0; visibleRow < numberOfVisibleItems; ++visibleRow)// relative_index
     {
         flatInventoryIndex = visibleRow + baseCursorPosition;
-        if (gContext.battle_inventory->get_resource(flatInventoryIndex).item_id != 0xFFFF)// if there is no item in the inventory at this index
+        if (gContext.battleInventory->get_resource(flatInventoryIndex).item_id != 0xFFFF)// if there is no item in the inventory at this index
         {
-            itemID = gContext.battle_inventory->get_resource(flatInventoryIndex).item_id;
-            itemQuantity = gContext.battle_inventory->get_resource(flatInventoryIndex).quantity;
+            itemID = gContext.battleInventory->get_resource(flatInventoryIndex).item_id;
+            itemQuantity = gContext.battleInventory->get_resource(flatInventoryIndex).quantity;
 
             if ((*COMMAND_TRIGGER_INDEX) != 3 && (*COMMAND_TRIGGER_INDEX) != 10)
                 textColor = (isThrowable(itemID)) ? COLOR_WHITE : COLOR_GRAY;
@@ -88,7 +88,7 @@ SISTERRAY_API i32 renderBattleItemView() {
 /*Return True if the character is usable by the character attempting to use it*/
 bool isUsableInBattle(u16 itemID) {
     auto restrictionMask = get_restriction_mask(itemID);
-    auto characterMask = gContext.item_on_use_data.get_resource(itemID).characterRestrictionMask;
+    auto characterMask = gContext.itemOnUseData.get_resource(itemID).characterRestrictionMask;
     bool itemIsUsuable = (bool)(!(restrictionMask & 2));
 
     auto party_member_index = (*ACTIVE_MENU_OWNER_PARTY_INDEX);
@@ -100,7 +100,7 @@ bool isUsableInBattle(u16 itemID) {
 
 bool isThrowable(u16 itemID) {
     auto restrictionMask = get_restriction_mask(itemID);
-    auto characterMask = gContext.item_on_use_data.get_resource(itemID).characterRestrictionMask;
+    auto characterMask = gContext.itemOnUseData.get_resource(itemID).characterRestrictionMask;
     bool itemIsThrowable = (bool)(!(restrictionMask & 8)); // Use new throwable variable
 
     auto party_member_index = (*ACTIVE_MENU_OWNER_PARTY_INDEX);
@@ -131,12 +131,12 @@ SISTERRAY_API void battleItemMenuInputHandler() {
                 if (checkInputReceived(32)) {
                     *ACCEPTING_BATTLE_INPUT = 1;
                     flatInventoryIndex = *((u16*)viewContextPtr + 10) + *((u16*)viewContextPtr + 2) + *((u16 *)viewContextPtr);
-                    itemID = gContext.battle_inventory->get_resource(flatInventoryIndex).item_id;
+                    itemID = gContext.battleInventory->get_resource(flatInventoryIndex).item_id;
                     actionSucceeded = didItemUseSucceed(itemID);
 
                     if (actionSucceeded) {
                         playMenuSound(1);
-                        targetData = gContext.battle_inventory->get_resource(flatInventoryIndex).targetFlags;
+                        targetData = gContext.battleInventory->get_resource(flatInventoryIndex).targetFlags;
 
                         *GLOBAL_ACTION_USED = itemID;
                         *GLOBAL_USED_ACTION_TARGET_DATA = targetData;

--- a/src/menus/equip_menu/equip_draw_callbacks.cpp
+++ b/src/menus/equip_menu/equip_draw_callbacks.cpp
@@ -89,7 +89,7 @@ void handleUpdateGearSlotsWidget(const EquipDrawEvent* event) {
     if (materiaGrowth < 0 || materiaGrowth > 3) //display any invalid materia growth as "None"
         materiaGrowth = 4;
 
-    const char * menuText = gContext.game_strings.equipMenuTexts.get_string(materiaGrowth + 11);
+    const char * menuText = gContext.gameStrings.equipMenuTexts.get_string(materiaGrowth + 11);
     i32 growthTypeY = equipMenuWindowConfig[2].drawDistance2 + 64;
     i32 growthTypeX = sub_6F54A2((u8*)menuText);
     moveWidget(growthWidget, 243 - growthTypeX / 2, growthTypeY);

--- a/src/menus/equip_menu/equip_init_callbacks.cpp
+++ b/src/menus/equip_menu/equip_init_callbacks.cpp
@@ -45,7 +45,7 @@ void initCharDataWidget(const EquipInitEvent* event) {
     std::vector<std::string> gearNames = { GEAR_SLOT_1_NAME, GEAR_SLOT_2_NAME, GEAR_SLOT_3_NAME };
     std::vector<std::string> equippedGearNames = { EQUIPPED_WEAPON, EQUIPPED_ARMOR, EQUIPPED_ACC };
     for (int row = 0; row < gearNames.size(); row++) {
-        menuText = gContext.game_strings.equipMenuTexts.get_string(row);
+        menuText = gContext.gameStrings.equipMenuTexts.get_string(row);
         setTextParams(&textParams, 250, 13 + (34 * row), menuText, COLOR_TEAL, 0.2f);
         textWidget = createTextWidget(textParams, gearNames[row]);
         addChildWidget(currentEquipWidget, (Widget*)textWidget, gearNames[row]);
@@ -120,7 +120,7 @@ void initGearMateriaSlotWidget(const EquipInitEvent* event) {
 
     std::vector<std::string> equipSlotDataNames = { SLOTS_NAME, GROWTH_NAME };
     for (int i = 0; i < 2; i++) {
-        menuText = gContext.game_strings.equipMenuTexts.get_string(14 + i);
+        menuText = gContext.gameStrings.equipMenuTexts.get_string(14 + i);
         setTextParams(&textParams, 27, 42 * i + equipMenuWindowConfig[2].drawDistance2 + 21, menuText, COLOR_TEAL, 0.1f);
         textWidget = createTextWidget(textParams, equipSlotDataNames[i]);
         addChildWidget(equipMateraSlotWidget, (Widget*)textWidget, equipSlotDataNames[i]);
@@ -135,7 +135,7 @@ void initGearMateriaSlotWidget(const EquipInitEvent* event) {
     if (materiaGrowth < 0 || materiaGrowth > 3) //display any invalid materia growth as "None"
         materiaGrowth = 4;
 
-    menuText = gContext.game_strings.equipMenuTexts.get_string(materiaGrowth + 4);
+    menuText = gContext.gameStrings.equipMenuTexts.get_string(materiaGrowth + 4);
     i32 growthTypeY = equipMenuWindowConfig[2].drawDistance2 + 64;
     i32 growthTypeX = 35;
     setTextParams(&textParams, 243 - growthTypeX / 2, growthTypeY, menuText, COLOR_WHITE, 0.2f);
@@ -178,7 +178,7 @@ void initStatDiffWidget(const EquipInitEvent* event) {
     std::vector<std::string> candidateNumberNames = { NEW_STAT_VALUE_1, NEW_STAT_VALUE_2, NEW_STAT_VALUE_3, NEW_STAT_VALUE_4, NEW_STAT_VALUE_5, NEW_STAT_VALUE_6, NEW_STAT_VALUE_7 };
     std::vector<std::string> arrowNames = { ARROW_1, ARROW_2, ARROW_3, ARROW_4, ARROW_5, ARROW_6, ARROW_7 };
     for (i32 i = 0; i < 7; ++i) {
-        menuText = gContext.game_strings.equipMenuTexts.get_string(3 + i);
+        menuText = gContext.gameStrings.equipMenuTexts.get_string(3 + i);
         setTextParams(&textParams, 53, windowTop + 26 * i - 6, menuText, COLOR_TEAL, 0.2f);
         textWidget = createTextWidget(textParams, statNames[i]);
         addChildWidget(statDiffWidget, (Widget*)textWidget, statNames[i]);

--- a/src/menus/equip_menu/equip_input_callbacks.cpp
+++ b/src/menus/equip_menu/equip_input_callbacks.cpp
@@ -205,7 +205,7 @@ void handleMateriaUpdate(characterRecord& activeCharacterRecord, u8 gearType, u1
 
         if (shouldRemove) {
             *byte_DC1148 = 0;
-            gContext.materia_inventory->insertIntoMateriaInventory((MateriaInventoryEntry*)equippedMateriaData[materiaSlotIndex]); //put any materia removed back on, needs to work with the SR materia
+            gContext.materiaInventory->insertIntoMateriaInventory((MateriaInventoryEntry*)equippedMateriaData[materiaSlotIndex]); //put any materia removed back on, needs to work with the SR materia
             *byte_DC1148 = 0;
             equippedMateriaData[materiaSlotIndex] = 0xFFFFFFFF;
         }

--- a/src/menus/inventory_menu/inventory_draw_callbacks.cpp
+++ b/src/menus/inventory_menu/inventory_draw_callbacks.cpp
@@ -66,7 +66,7 @@ void handleUpdateDescription(const InventoryDrawEvent* event) {
             flatInventoryIndex = (keyItemChoice.maxColumnBound * (keyItemChoice.baseRowIndex + keyItemChoice.relativeRowIndex)) + keyItemChoice.relativeColumnIndex;
             if ((KEY_ITEMS_INVENTORY_PTR)[flatInventoryIndex] != 0xFFFF) {
                 auto keyItemID = (KEY_ITEMS_INVENTORY_PTR)[flatInventoryIndex];
-                fetchedDescription = gContext.game_strings.key_item_descriptions.get_string(keyItemID);
+                fetchedDescription = gContext.gameStrings.key_item_descriptions.get_string(keyItemID);
                 updateText(getChild(itemDescWidget, ITEM_DESCRIPTION), fetchedDescription);
             }
             else {

--- a/src/menus/inventory_menu/inventory_init_callbacks.cpp
+++ b/src/menus/inventory_menu/inventory_init_callbacks.cpp
@@ -36,7 +36,7 @@ void initViewChoiceWidget(const InventoryInitEvent* event) {
 
     std::vector<std::string> listNames = { INV_VIEW_1, INV_VIEW_2, INV_VIEW_3 };
     for (int column = 0; column < 3; ++column) {
-        setTextParams(&textParams, 98 * column + 57, 17, gContext.game_strings.inventory_menu_texts.get_string(column), COLOR_WHITE, 0.1f);
+        setTextParams(&textParams, 98 * column + 57, 17, gContext.gameStrings.inventory_menu_texts.get_string(column), COLOR_WHITE, 0.1f);
         auto textChild = createTextWidget(textParams, listNames[column]);
         addChildWidget(viewChoiceWidget, (Widget*)textChild, listNames[column]);
     }
@@ -221,7 +221,7 @@ void arrangeTypeWidget(const InventoryInitEvent* event) {
     //Probably a good case to be made here for a new static Grid with no updater here
     std::vector<std::string> listNames = { SORT_TYPE_1, SORT_TYPE_2, SORT_TYPE_3, SORT_TYPE_4, SORT_TYPE_5, SORT_TYPE_6, SORT_TYPE_7, SORT_TYPE_8 };
     for (int sortType = 0; sortType < listNames.size(); ++sortType) {
-        const char* fetchedDescription = gContext.game_strings.inventory_menu_texts.get_string(sortType + 3);
+        const char* fetchedDescription = gContext.gameStrings.inventory_menu_texts.get_string(sortType + 3);
         setTextParams(&textParams, boxParams.drawDistance1 + 13, boxParams.drawDistance2 + 26 * sortType + 13, fetchedDescription, COLOR_WHITE, 0.001f);
         auto textChild = createTextWidget(textParams, listNames[sortType]);
         addChildWidget(arrangeTypeWidget, (Widget*)textChild, listNames[sortType]);

--- a/src/menus/inventory_menu/inventory_input_callbacks.cpp
+++ b/src/menus/inventory_menu/inventory_input_callbacks.cpp
@@ -46,7 +46,7 @@ void selectItemHandler(const InventoryInputEvent* event) {
         if (usableInInventoryMenu(itemID)) {
             playMenuSound(3);
         }
-        else if (!(gContext.item_on_use_data.get_resource(itemID).requires_target)) {
+        else if (!(gContext.itemOnUseData.get_resource(itemID).requires_target)) {
             gContext.untargeted_handlers.get_handler(itemID)();
             
         }
@@ -91,7 +91,7 @@ void useTargetedItemHandler(const InventoryInputEvent* event) {
     u32 partyMemberIndex = getStateCursor(event->menu, 2)->context.relativeRowIndex;
 
     u8 character_ID = (CURRENT_PARTY_MEMBER_ARRAY)[partyMemberIndex];
-    if (character_ID == 0xFF && !(gContext.item_on_use_data.get_resource(itemID).target_all)) {
+    if (character_ID == 0xFF && !(gContext.itemOnUseData.get_resource(itemID).target_all)) {
         playMenuSound(3);
         return;
     }
@@ -172,7 +172,7 @@ void handleUsableItemEffects(u16 item_ID, u16 inventory_index, u32 partyMemberIn
     auto itemWasUsed = false;
 
     /*Call the appropriate function handler for using items on a character/the party*/
-    itemWasUsed = gContext.on_use_handlers.get_handler(item_ID)((u16)partyMemberIndex, item_ID, inventory_index);
+    itemWasUsed = gContext.onUseHandlers.get_handler(item_ID)((u16)partyMemberIndex, item_ID, inventory_index);
     if (itemWasUsed) {
         gContext.inventory->decrementInventoryEntry(inventory_index, 1);
         if (gContext.inventory->get_resource(inventory_index).item_id == 0xFFFF)// If the Inventory Entry is -1, i.e it has been used up

--- a/src/menus/inventory_menu/inventory_menu.cpp
+++ b/src/menus/inventory_menu/inventory_menu.cpp
@@ -57,7 +57,7 @@ void displayActiveCursorStates(Menu* menu, u16 menuState, u32 updateStateMask) {
             if (!(*use_on_characters_enabled)) {
                 auto characterChoiceCursor = getStateCursor(menu, 2);
                 item_ID = gContext.inventory->get_resource(itemChoiceCursor->context.baseRowIndex + itemChoiceCursor->context.relativeRowIndex).item_id;;
-                if (!(gContext.item_on_use_data.get_resource(item_ID).target_all))
+                if (!(gContext.itemOnUseData.get_resource(item_ID).target_all))
                     drawCursor(characterChoiceCursor, 0.0f);
                 else
                     displayCursor(0, 120 * (updateStateMask % 3) + 161, 0.0);

--- a/src/party/characters.cpp
+++ b/src/party/characters.cpp
@@ -1,0 +1,21 @@
+#include "characters.h"
+#include "../impl.h"
+
+#define CHARACTER_BLOCK_SIZE 3988
+
+SISTERRAY_API void initCharacterData(SrKernelStream* stream) {
+    gContext.characters = SrCharacterRegistry();
+    u8* sectionBuffer = (u8*)malloc(CHARACTER_BLOCK_SIZE);
+    srKernelStreamRead(stream, (void*)sectionBuffer, CHARACTER_BLOCK_SIZE);
+    auto characterAIPtr = sectionBuffer + 0x61C;
+
+    for (auto characterIndex = 0; characterIndex < 12; characterIndex++) {
+        auto characterData = SrCharacterData();
+        BattleAIData characterAIData = BattleAIData();
+        initializeBattleAIData(characterAIPtr, characterIndex, characterAIData);
+        characterData.characterAI = characterAIData;
+        auto charName = getCharacterName(characterIndex);
+        gContext.characters.add_element(charName, characterData);
+    }
+    srLogWrite("kernel.bin: Loaded %lu character AI scripts", (unsigned long)gContext.characters.resource_count());
+}

--- a/src/party/characters.cpp
+++ b/src/party/characters.cpp
@@ -4,12 +4,14 @@
 #define CHARACTER_BLOCK_SIZE 3988
 
 SISTERRAY_API void initCharacterData(SrKernelStream* stream) {
+    srLogWrite("loading character AI Data");
     gContext.characters = SrCharacterRegistry();
     u8* sectionBuffer = (u8*)malloc(CHARACTER_BLOCK_SIZE);
     srKernelStreamRead(stream, (void*)sectionBuffer, CHARACTER_BLOCK_SIZE);
     auto characterAIPtr = sectionBuffer + 0x61C;
 
     for (auto characterIndex = 0; characterIndex < 12; characterIndex++) {
+        srLogWrite("attemping to load AI scripts for character %i", characterIndex);
         auto characterData = SrCharacterData();
         BattleAIData characterAIData = BattleAIData();
         initializeBattleAIData(characterAIPtr, characterIndex, characterAIData);

--- a/src/party/characters.h
+++ b/src/party/characters.h
@@ -1,0 +1,21 @@
+#ifndef CHARACTERS_H
+#define CHARACTERS_H
+
+#include <SisterRay/types.h>
+#include <SisterRay/SisterRay.h>
+#include "../sr_named_registry.h"
+#include "../battle/ai_scripts.h"
+#include "party_utils.h"
+
+typedef struct {
+    BattleAIData characterAI;
+} SrCharacterData;
+
+/*The following registries contain enemy data and AI scripts indexed by the absolute ID of the enemy*/
+class SrCharacterRegistry : public SrNamedResourceRegistry<SrCharacterData, std::string> {
+public:
+    SrCharacterRegistry() : SrNamedResourceRegistry<SrCharacterData, std::string>() {}
+};
+
+SISTERRAY_API void initCharacterData(SrKernelStream* stream);
+#endif

--- a/src/party/party_utils.cpp
+++ b/src/party/party_utils.cpp
@@ -1,6 +1,36 @@
 #include "party_utils.h"
 #include "../inventories/inventory_utils.h"
 
+std::string getCharacterName (u8 characterID) {
+    switch (characterID) {
+        case 0:
+            return std::string("CLOUD");
+        case 1:
+            return std::string("BARRET");
+        case 2:
+            return std::string("TIFA");
+        case 3:
+            return std::string("AERIS");
+        case 4:
+            return std::string("REDXIII");
+        case 5:
+            return std::string("YUFFIE");
+        case 6:
+            return std::string("CAITSITH");
+        case 7:
+            return std::string("VINCENT");
+        case 8:
+            return std::string("CID");
+        case 9:
+            return std::string("YCLOUD");
+        case 10:
+            return std::string("SEPHIROTH");
+        default: {
+            return std::string("NULL");
+        }
+    }
+}
+
 u16 getEquippedGear(u8 characterID, u8 gearType) {
     characterRecord* characterRecordArray = CHARACTER_RECORD_ARRAY;
     u16 kernelObjectID;

--- a/src/party/party_utils.h
+++ b/src/party/party_utils.h
@@ -3,8 +3,10 @@
 
 #include <SisterRay/types.h>
 #include <SisterRay/SisterRay.h>
+#include <string>
 
 u16 getEquippedGear(u8 characterID, u8 gearType);
 bool characterCanEquipItem(u8 characterID, u16 item_id);
+std::string getCharacterName(u8 characterID);
 
 #endif

--- a/src/sr_named_registry.h
+++ b/src/sr_named_registry.h
@@ -32,6 +32,11 @@ public:
     u32 get_resource_index(const std::string& name) {
         return named_registry[name];
     }
+
+    bool contains(const std::string& name) {
+        auto doesContain = (named_registry.find(name) == named_registry.end()) ? false : true;
+        return doesContain;
+    }
 };
 
 #endif

--- a/src/sr_registry_template.h
+++ b/src/sr_registry_template.h
@@ -16,6 +16,7 @@ public:
         size_t read_size;
         T object;
 
+        /*Here we read from the KernelStream */
         for (;;) {
             read_size = srKernelStreamRead(stream, &object, sizeof(object));
             if (read_size != sizeof(object))
@@ -51,26 +52,21 @@ public:
         _resource_registry.push_back(resource);
     }
 
-    void update_resource(u32 index, const T& resource)
-    {
-        if (index < resource_count())
-        {
+    void update_resource(u32 index, const T& resource) {
+        if (index < resource_count()) {
             _resource_registry[index] = resource;
         }
     }
 
-    size_t resource_count()
-    {
+    size_t resource_count() {
         return _resource_registry.size();
     }
 
-    size_t current_capacity()
-    {
+    size_t current_capacity() {
         return _resource_registry.capacity();
     }
 
-    T* get_data()
-    {
+    T* get_data() {
         return _resource_registry.data();
     }
 

--- a/src/sr_registry_template.h
+++ b/src/sr_registry_template.h
@@ -16,8 +16,7 @@ public:
         size_t read_size;
         T object;
 
-        for (;;)
-        {
+        for (;;) {
             read_size = srKernelStreamRead(stream, &object, sizeof(object));
             if (read_size != sizeof(object))
                 break;
@@ -26,37 +25,29 @@ public:
     }
 
     /*Constructor used for fixed size arrays, like the inventory*/
-    SrResourceRegistry(u32 reserve_size)
-    {
+    SrResourceRegistry(u32 reserve_size) {
         _resource_registry.reserve(reserve_size);
     }
 
     /*Default constructor*/
-    SrResourceRegistry() {
-    }
-    ~SrResourceRegistry() {
-    }
+    SrResourceRegistry() {}
+    ~SrResourceRegistry() {}
 
-    const T& get_resource(u32 index) const
-    {
-        if (index >= resource_count())
-        {
+    const T& get_resource(u32 index) const {
+        if (index >= resource_count()) {
             return _null;
         }
         return _resource_registry[index];
     }
 
-    T& get_resource(u32 index)
-    {
-        if (index >= resource_count())
-        {
+    T& get_resource(u32 index) {
+        if (index >= resource_count()) {
             return _null;
         }
         return _resource_registry[index];
     }
 
-    void add_resource(const T& resource)
-    {
+    void add_resource(const T& resource) {
         _resource_registry.push_back(resource);
     }
 

--- a/src/string_registry.cpp
+++ b/src/string_registry.cpp
@@ -28,74 +28,74 @@ void StringRegistry::set_unicode_string(int index, const char* str)
 void initGameStrings()
 {
     for (int i = 0; i <= 11; i++) {
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Wpn"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Arm"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Acc"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Attack"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Hit"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Defense"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Evade"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("M.Atk"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("M.Defense"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("M.Evade"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("None"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Normal"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Double"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Triple"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Slots"));
-        gContext.game_strings.equipMenuTexts.add_resource(EncodedString::from_unicode("Growth"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Wpn"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Arm"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Acc"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Attack"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Hit"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Defense"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Evade"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("M.Atk"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("M.Defense"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("M.Evade"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("None"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Normal"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Double"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Triple"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Slots"));
+        gContext.gameStrings.equipMenuTexts.add_resource(EncodedString::from_unicode("Growth"));
     }
 
     for (int i = 0; i <= 11; i++) {
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Use"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Arrange"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Key Items"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Customize"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Field"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Battle"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Throw"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Type"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Name"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Most"));
-        gContext.game_strings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Least"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Use"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Arrange"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Key Items"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Customize"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Field"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Battle"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Throw"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Type"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Name"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Most"));
+        gContext.gameStrings.inventory_menu_texts.add_resource(EncodedString::from_unicode("Least"));
     }
 }
 
 const char* getNameFromRelativeID(u16 relativeID, u8 itemType) {
     switch (itemType) {
     case 0:
-        return gContext.game_strings.item_names.get_string(relativeID);
+        return gContext.gameStrings.item_names.get_string(relativeID);
         break;
     case 1:
-        return gContext.game_strings.weapon_names.get_string(relativeID);
+        return gContext.gameStrings.weapon_names.get_string(relativeID);
         break;
     case 2:
-        return gContext.game_strings.armor_names.get_string(relativeID);
+        return gContext.gameStrings.armor_names.get_string(relativeID);
         break;
     case 3:
-        return gContext.game_strings.accessory_names.get_string(relativeID);
+        return gContext.gameStrings.accessory_names.get_string(relativeID);
         break;
     default:
-        return gContext.game_strings.item_names.get_string(relativeID);
+        return gContext.gameStrings.item_names.get_string(relativeID);
     }
 }
 
 const char* getDescriptionFromRelativeID(u16 relativeID, u8 itemType) {
     switch (itemType) {
     case 0:
-        return gContext.game_strings.item_descriptions.get_string(relativeID);
+        return gContext.gameStrings.item_descriptions.get_string(relativeID);
         break;
     case 1:
-        return gContext.game_strings.weapon_descriptions.get_string(relativeID);
+        return gContext.gameStrings.weapon_descriptions.get_string(relativeID);
         break;
     case 2:
-        return gContext.game_strings.armor_descriptions.get_string(relativeID);
+        return gContext.gameStrings.armor_descriptions.get_string(relativeID);
         break;
     case 3:
-        return gContext.game_strings.accessory_descriptions.get_string(relativeID);
+        return gContext.gameStrings.accessory_descriptions.get_string(relativeID);
         break;
     default:
-        return gContext.game_strings.item_descriptions.get_string(relativeID);
+        return gContext.gameStrings.item_descriptions.get_string(relativeID);
     }
 }
 

--- a/src/usable_item_handlers.cpp
+++ b/src/usable_item_handlers.cpp
@@ -25,11 +25,11 @@ void initOnUseCallbackRegistry() {
         case 5:
         case 6:
         case 7: {
-            gContext.on_use_handlers.add_resource("heal_party_member");
+            gContext.onUseHandlers.add_resource("heal_party_member");
             break;
         }
         default:
-            gContext.on_use_handlers.add_resource("no_function");
+            gContext.onUseHandlers.add_resource("no_function");
         }
     }
 }
@@ -38,9 +38,9 @@ void initNoTargetCallbackRegistry() {
     for (u16 item_id = 0; item_id < 320; item_id++) {
         switch (item_id) {
         case 98:
-            gContext.on_use_handlers.add_resource("save_crystal_handler");
+            gContext.onUseHandlers.add_resource("save_crystal_handler");
         default:
-            gContext.on_use_handlers.add_resource("no_function");
+            gContext.onUseHandlers.add_resource("no_function");
         }
     }
 }
@@ -70,7 +70,7 @@ bool default_item_use(u16 party_member_index, u16 item_id, u16 inventory_index) 
 bool heal_handler(u16 party_member_index, u16 item_id, u16 inventory_index) {
     bool use_successful = false;
     bool temp_bool;
-    auto target_all = gContext.item_on_use_data.get_resource(item_id).target_all;
+    auto target_all = gContext.itemOnUseData.get_resource(item_id).target_all;
 
     if (target_all) {
         for (u16 member_to_heal = 0; member_to_heal < 3; ++member_to_heal) {
@@ -92,8 +92,8 @@ bool heal_single_party_member(u16 party_member_index, u16 item_id) {
     bool heal_was_performed = false;
     auto is_hp_healable = check_target_hp_healable(party_member_index, item_id);
     auto is_mp_healable = check_target_mp_healable(party_member_index, item_id);
-    auto item_heals_hp = (gContext.item_on_use_data.get_resource(item_id).hp_heal_amount || gContext.item_on_use_data.get_resource(item_id).hp_heal_percent);
-    auto item_heals_mp = (gContext.item_on_use_data.get_resource(item_id).mp_heal_amount || gContext.item_on_use_data.get_resource(item_id).mp_heal_percent);
+    auto item_heals_hp = (gContext.itemOnUseData.get_resource(item_id).hp_heal_amount || gContext.itemOnUseData.get_resource(item_id).hp_heal_percent);
+    auto item_heals_mp = (gContext.itemOnUseData.get_resource(item_id).mp_heal_amount || gContext.itemOnUseData.get_resource(item_id).mp_heal_percent);
 
     if (item_heals_hp) {
         if (is_hp_healable) {
@@ -113,22 +113,22 @@ bool heal_single_party_member(u16 party_member_index, u16 item_id) {
 }
 
 u16 calculate_hp_heal_amount(u16 party_member_index, u16 item_id) {
-    if (gContext.item_on_use_data.get_resource(item_id).hp_heal_amount) {
-        return gContext.item_on_use_data.get_resource(item_id).hp_heal_amount;
+    if (gContext.itemOnUseData.get_resource(item_id).hp_heal_amount) {
+        return gContext.itemOnUseData.get_resource(item_id).hp_heal_amount;
     }
-    else if (gContext.item_on_use_data.get_resource(item_id).hp_heal_percent){
-        u8 heal_divisor = gContext.item_on_use_data.get_resource(item_id).hp_heal_percent;
+    else if (gContext.itemOnUseData.get_resource(item_id).hp_heal_percent){
+        u8 heal_divisor = gContext.itemOnUseData.get_resource(item_id).hp_heal_percent;
         return (((activePartyStructArray)[party_member_index].maxHP / heal_divisor) * 100);
     }
     return 0;
 }
 
 u16 calculate_mp_heal_amount(u16 party_member_index, u16 item_id) {
-    if (gContext.item_on_use_data.get_resource(item_id).mp_heal_amount) {
-        return gContext.item_on_use_data.get_resource(item_id).mp_heal_amount;
+    if (gContext.itemOnUseData.get_resource(item_id).mp_heal_amount) {
+        return gContext.itemOnUseData.get_resource(item_id).mp_heal_amount;
     }
-    else if (gContext.item_on_use_data.get_resource(item_id).mp_heal_percent) {
-        u8 heal_divisor = gContext.item_on_use_data.get_resource(item_id).mp_heal_percent;
+    else if (gContext.itemOnUseData.get_resource(item_id).mp_heal_percent) {
+        u8 heal_divisor = gContext.itemOnUseData.get_resource(item_id).mp_heal_percent;
         return (((activePartyStructArray)[party_member_index].maxMP / heal_divisor) * 100);
     }
     return 0;
@@ -137,7 +137,7 @@ u16 calculate_mp_heal_amount(u16 party_member_index, u16 item_id) {
 bool check_target_hp_healable(u16 target, u16 item_id) {
     bool is_healable = check_character_hp_full(target);
 
-    if (gContext.item_on_use_data.get_resource(item_id).can_revive) {
+    if (gContext.itemOnUseData.get_resource(item_id).can_revive) {
         return is_healable;
     }
 
@@ -148,7 +148,7 @@ bool check_target_hp_healable(u16 target, u16 item_id) {
 bool check_target_mp_healable(u16 target, u16 item_id) {
     bool is_healable = check_character_mp_full(target);
 
-    if (gContext.item_on_use_data.get_resource(item_id).can_revive) {
+    if (gContext.itemOnUseData.get_resource(item_id).can_revive) {
         return is_healable;
     }
 
@@ -180,7 +180,7 @@ void play_success_or_failure_sound(bool did_succeed, i32 success_sound_id, i32 f
 /*Perhaps redesign to make it possible to boost multiple stats, lower stats, or boost by variable amounts*/
 bool permanently_boost_stat(u16 party_member_index, u16 item_id, u16 inventory_index) {
     u8 character_ID = (CURRENT_PARTY_MEMBER_ARRAY)[party_member_index];
-    u8 stat_to_boost = gContext.item_on_use_data.get_resource(item_id).stat_to_boost;
+    u8 stat_to_boost = gContext.itemOnUseData.get_resource(item_id).stat_to_boost;
     bool stat_boosted = false;
     switch (stat_to_boost) {
         case 0: {
@@ -246,26 +246,26 @@ bool teach_limit_breaks(u16 party_member_index, u16 item_id, u16 inventory_index
     u8 character_ID = (u8)(CURRENT_PARTY_MEMBER_ARRAY)[party_member_index];
     bool item_usable = character_can_use_item(character_ID, item_id); //If the character can't use the item, give the old "nothing to do with me message"
     bool limit_taught = false;
-    auto registry = gContext.game_strings.character_specific_strings[character_ID];
+    auto registry = gContext.gameStrings.character_specific_strings[character_ID];
     if (item_usable) {
         if (knows_all_prereq_limits(character_ID)) { //Check if requisite limits are learned
             playMenuSound(384);
             CHARACTER_RECORD_ARRAY[character_ID].learned_limits = (CHARACTER_RECORD_ARRAY[character_ID].learned_limits | 0x0200);
-            auto limit_learned_string = gContext.game_strings.character_specific_strings[character_ID].get_string(0); //String 0 is a characters "limit learned" string
+            auto limit_learned_string = gContext.gameStrings.character_specific_strings[character_ID].get_string(0); //String 0 is a characters "limit learned" string
             displayNewBoxString(limit_learned_string); //Get limit learned text, need to build out custom string storage
             sub_6C497C((int)byte_DD18C8, 7); //The game does this casting of a pointer as an arg... is ugly
             limit_taught = true;
         }
         else
         {
-            auto not_ready_string = gContext.game_strings.character_specific_strings[character_ID].get_string(1);
+            auto not_ready_string = gContext.gameStrings.character_specific_strings[character_ID].get_string(1);
             displayNewBoxString(not_ready_string); //get can't learn limit yet text. Can fetch from our own managed text array
             sub_6C497C((int)byte_DD18C8, 7);
             playMenuSound(3);
         }
     }
     else {
-        auto cannot_learn_string = gContext.game_strings.character_specific_strings[character_ID].get_string(2);
+        auto cannot_learn_string = gContext.gameStrings.character_specific_strings[character_ID].get_string(2);
         displayNewBoxString(cannot_learn_string); //get can't learn limit text
         sub_6C497C((int)byte_DD18C8, 7);
         playMenuSound(3);

--- a/src/widgets/updater.cpp
+++ b/src/widgets/updater.cpp
@@ -64,7 +64,7 @@ void keyItemViewNameUpdater(CollectionWidget* self, Widget* widget, u16 flatInde
     auto keyItemIndex = (KEY_ITEMS_INVENTORY_PTR)[(u8)(flatIndex)];
     if (keyItemIndex != 0xFFFF) {
         enableWidget(widget);
-        const char* name = gContext.game_strings.key_item_names.get_string(flatIndex);
+        const char* name = gContext.gameStrings.key_item_names.get_string(flatIndex);
         updateText(widget, name);
         updateTextColor(widget, COLOR_WHITE);
     }


### PR DESCRIPTION
Loads AI scripts into Sr registries and dispatches them from those registries, removing length constraints.
Loads scene Data into separate registries for Formation, Enemy Abilities, and Enemy Data, removing more constraints.

Contains rewritten functions to execute AI scripts from the new srLocations and to load ability data in a generic way (we no longer copy all scene attacks into the temp buffer, but as an ability is used by an enemy, it is copied into the temp buffer from our registries)