### PR TITLE
Hook internal game debug function

### DIFF
--- a/include/SisterRay/routines.h
+++ b/include/SisterRay/routines.h
@@ -44,6 +44,7 @@
 #define DISPATCH_AUTO_ACTIONS           ((void*)0x5C8CFA)
 #define DISPATCH_BATTLE_UPDATES         ((void*)0x6CE8B3)
 #define INIT_BATTLE_DATA                ((void*)0x6DB716)
+#define PRINT_DEBUG_STRING              ((void*)0x664E30)
 
 typedef void(*pfnnullmasks)();
 typedef void(*pfnenqueueaction)(u16, u16, u8, u8, u16);

--- a/src/impl.h
+++ b/src/impl.h
@@ -114,6 +114,9 @@ SISTERRAY_API const void* srLoadFunction(const char* name);
 SISTERRAY_API const void* srRegisterFunction(const char* name, const void* func);
 SISTERRAY_API const char* srGetGamePath(const char* suffix);
 
+// In-Game internal debugging
+void gameLogWrite(const char* str);
+
 /*For testing redirection of animation scripts*/
 typedef void (PFNRUNANIMSCRIPT)(u16, u32, u32, u32);
 SISTERRAY_GLOBAL PFNRUNANIMSCRIPT* oldRunAnimationScript;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -162,6 +162,7 @@ static void Init(void) {
     mogReplaceFunction(RECALCULATE_DERIVED_STATS, &srRecalculateDerivedStats);
     mogReplaceFunction(DISPATCH_AUTO_ACTIONS, &dispatchAutoActions);
     mogReplaceFunction(UPDATE_COMMANDS_ACTIVE, &updateCommandsActive);
+    mogReplaceFunction(PRINT_DEBUG_STRING, &gameLogWrite);
     initializeBattleMenu();
     srLogWrite("initialization complete");
     LoadMods();

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -14,6 +14,10 @@ SISTERRAY_API void initLog(void)
     atexit(LogExitHandler);
 }
 
+void gameLogWrite(const char* str) {
+    srLogWrite("ff7.exe: %s", str);
+}
+
 SISTERRAY_API void srLogWrite(const char* format, ...)
 {
     char buffer[4096];
@@ -22,7 +26,7 @@ SISTERRAY_API void srLogWrite(const char* format, ...)
     va_start(ap, format);
     vsnprintf(buffer, sizeof(buffer), format, ap);
     fwrite(buffer, strlen(buffer), 1, gContext.logFile);
-    fwrite("\r\n", 2, 1, gContext.logFile);
+    if(!strstr(buffer, "\n")) fwrite("\n", 1, 1, gContext.logFile);
     fflush(gContext.logFile);
     va_end(ap);
 }


### PR DESCRIPTION
And redirect output to Sisteray log file. Prefix internal game logs with binary name.

Here you can find an example log: [SisterRay.log](https://github.com/FFT-Hackers/SisterRay/files/3902470/SisterRay.log)
